### PR TITLE
fix: rename router to api_router in router.py

### DIFF
--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -17,16 +17,16 @@ from app.api.v1.endpoints import (
 )
 
 # Create main router
-router = APIRouter()
+api_router = APIRouter()
 
 # Include all endpoint routers
-router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
-router.include_router(password_reset.router, tags=["Authentication"])  # Add password reset routes
-router.include_router(trading.router, prefix="/trading", tags=["Trading"])
-router.include_router(exchanges.router, prefix="/exchanges", tags=["Exchanges"])
-router.include_router(strategies.router, prefix="/strategies", tags=["Strategies"])
-router.include_router(credits.router, prefix="/credits", tags=["Credits"])
-router.include_router(chat.router, prefix="/chat", tags=["Chat"])
-router.include_router(telegram.router, prefix="/telegram", tags=["Telegram"])
-router.include_router(paper_trading.router, prefix="/paper-trading", tags=["Paper Trading"])
-router.include_router(admin.router, prefix="/admin", tags=["Admin"])
+api_router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
+api_router.include_router(password_reset.router, tags=["Authentication"])  # Add password reset routes
+api_router.include_router(trading.router, prefix="/trading", tags=["Trading"])
+api_router.include_router(exchanges.router, prefix="/exchanges", tags=["Exchanges"])
+api_router.include_router(strategies.router, prefix="/strategies", tags=["Strategies"])
+api_router.include_router(credits.router, prefix="/credits", tags=["Credits"])
+api_router.include_router(chat.router, prefix="/chat", tags=["Chat"])
+api_router.include_router(telegram.router, prefix="/telegram", tags=["Telegram"])
+api_router.include_router(paper_trading.router, prefix="/paper-trading", tags=["Paper Trading"])
+api_router.include_router(admin.router, prefix="/admin", tags=["Admin"])


### PR DESCRIPTION
- Fix import error in main.py by renaming router variable
- Update all include_router calls to use api_router

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal API router naming for consistency and clarity across the codebase.
  * No changes to available endpoints, URLs, prefixes, or tags; all routes remain exactly the same.
  * Authentication-related routes, including password reset, remain accessible as before.
  * Backward compatibility preserved; no client updates or configuration changes required.
  * No impact on performance, behavior, or response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->