### PR TITLE
Complete fix for login timeout issues on Render deployment

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -14,7 +14,7 @@ console.log('API Base URL:', API_BASE_URL);
 // Create axios instance
 export const apiClient: AxiosInstance = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 60000, // Increase to 60 seconds for slow Render services
+  timeout: 120000, // 2 minutes default timeout for Render cold starts
   headers: {
     'Content-Type': 'application/json',
   },
@@ -159,7 +159,8 @@ apiClient.interceptors.response.use(
 
     // Timeout errors
     if (error.code === 'ECONNABORTED') {
-      const timeoutError = new Error('Connection timeout. The server is taking longer than usual to respond. Please wait a moment and try again.');
+      console.error('Request timeout detected:', error.config?.url);
+      const timeoutError = new Error('Server is starting up. This may take up to 2 minutes on first request. Please wait and try again.');
       timeoutError.name = 'TimeoutError';
       return Promise.reject(timeoutError);
     }

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -40,79 +40,49 @@ export const useAuthStore = create<AuthStore>()(
         set({ isLoading: true, error: null, mfaRequired: false });
 
         try {
-          // Retry logic for slow Render services with proper exponential backoff
+          // Simple direct login with extended timeout for Render
           let response;
-          let retryCount = 0;
-          const maxRetries = 3;
-          const baseDelay = 1000; // 1 second base delay
-          const maxBackoff = 8000; // Maximum 8 seconds per retry
-          const overallTimeout = 45000; // 45 seconds total timeout
-          const startTime = Date.now();
           
-          while (retryCount <= maxRetries) {
-            // Calculate remaining budget before each attempt
-            const elapsedTime = Date.now() - startTime;
-            const remainingBudget = overallTimeout - elapsedTime;
+          try {
+            // First attempt with extended timeout
+            response = await apiClient.post('/auth/login', credentials, {
+              timeout: 120000 // 2 minutes timeout for slow Render cold starts
+            });
+          } catch (firstError: any) {
+            // Log error for debugging
+            console.error('First login attempt failed:', firstError.message);
             
-            if (remainingBudget <= 0) {
-              throw new Error('Login request exceeded maximum timeout. Please try again later.');
-            }
+            // Check if it's a timeout error
+            const isTimeoutError = firstError.code === 'ECONNABORTED' || 
+                                 /timeout/i.test(firstError.message || '') || 
+                                 /timeouterror/i.test(firstError.message || '');
             
-            try {
-              // Use remaining budget as per-request timeout
-              const requestTimeout = Math.max(1000, remainingBudget); // Minimum 1 second
-              response = await apiClient.post('/auth/login', credentials, {
-                timeout: requestTimeout
-              });
-              break; // Success, exit retry loop
-            } catch (error: any) {
-              retryCount++;
+            if (isTimeoutError) {
+              console.log('Timeout detected, trying once more with warm service...');
               
-              // Check remaining budget after failed attempt
-              const elapsedAfterAttempt = Date.now() - startTime;
-              const remainingAfterAttempt = overallTimeout - elapsedAfterAttempt;
+              // Wait 2 seconds for service to warm up
+              await new Promise(resolve => setTimeout(resolve, 2000));
               
-              if (remainingAfterAttempt <= 0) {
-                throw new Error('Login request exceeded maximum timeout. Please try again later.');
+              try {
+                // Second attempt - service should be warm now
+                response = await apiClient.post('/auth/login', credentials, {
+                  timeout: 60000 // 1 minute for warm service
+                });
+              } catch (secondError: any) {
+                console.error('Second login attempt also failed:', secondError.message);
+                
+                // If second attempt also fails, throw user-friendly error
+                throw new Error('Unable to connect to login service. The server may be starting up. Please wait a moment and try again.');
               }
-              
-              // Enhanced timeout detection (case-insensitive)
-              const isTimeoutError = error.code === 'ECONNABORTED' || 
-                                   /timeout/i.test(error.message || '') || 
-                                   /timeouterror/i.test(error.message || '');
-              
-              // If it's a timeout error and we have retries left
-              if (isTimeoutError && retryCount <= maxRetries) {
-                // Calculate exponential backoff with jitter
-                const exponentialDelay = Math.min(baseDelay * Math.pow(2, retryCount - 1), maxBackoff);
-                const jitterFactor = 0.5 + Math.random(); // Random between 0.5 and 1.5
-                const actualDelay = Math.floor(exponentialDelay * jitterFactor);
-                
-                // Only log in development
-                if (import.meta.env.DEV) {
-                  console.log(`Login attempt ${retryCount} failed, retrying in ${actualDelay}ms...`);
-                }
-                
-                // Wait for the calculated delay
-                await new Promise(resolve => setTimeout(resolve, actualDelay));
-                
-                // Check timeout again after wait
-                const elapsedAfterWait = Date.now() - startTime;
-                if (elapsedAfterWait >= overallTimeout) {
-                  throw new Error('Login request exceeded maximum timeout. Please try again later.');
-                }
-                
-                continue;
-              }
-              
-              // If not a timeout or out of retries, throw the error
-              throw error;
+            } else {
+              // Not a timeout error, throw original error
+              throw firstError;
             }
           }
           
-          // If we exhausted retries without success
+          // If no response after attempts
           if (!response) {
-            throw new Error('Login failed after maximum retry attempts. Please try again later.');
+            throw new Error('Login service unavailable. Please try again later.');
           }
           
           if (response.data.mfa_required) {


### PR DESCRIPTION
SIMPLIFIED APPROACH:
- Remove complex retry logic that was causing immediate timeout failures
- Implement simple 2-attempt strategy with extended timeouts
- First attempt: 2 minutes timeout for cold start scenarios
- Second attempt: 1 minute timeout after 2-second warm-up wait
- Clear console logging for debugging in production

TIMEOUT ADJUSTMENTS:
- Increase default axios timeout to 120 seconds (2 minutes)
- Remove problematic budget calculations that failed immediately
- Add explicit timeout per request attempt

USER EXPERIENCE:
- Better error messages explaining server startup delays
- Console logging to help debug issues in production
- Simplified logic reduces chance of bugs

This approach works better with Render's cold start behavior where the first request can take 30-60 seconds to respond.

🤖 Generated with [Claude Code](https://claude.ai/code)