### PR TITLE
Fix admin panel users display issue

### DIFF
--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -460,16 +460,6 @@ async def list_users(
         user_id=str(current_user.id)
     )
     
-    # Check if mock mode is enabled - DISABLED for now to show real users
-    # if settings.ADMIN_USERS_MOCK:
-    #     logger.warning("⚠️ ADMIN_USERS_MOCK is enabled - returning mock data. This should NOT be used in production!")
-    #     return UserListResponse(
-    #         users=[],
-    #         total_count=0,
-    #         active_count=0,
-    #         trading_count=0
-    #     )
-    
     try:
         # Build the base query using select statement for async
         stmt = select(User)

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -460,15 +460,15 @@ async def list_users(
         user_id=str(current_user.id)
     )
     
-    # Check if mock mode is enabled
-    if settings.ADMIN_USERS_MOCK:
-        logger.warning("⚠️ ADMIN_USERS_MOCK is enabled - returning mock data. This should NOT be used in production!")
-        return UserListResponse(
-            users=[],
-            total_count=0,
-            active_count=0,
-            trading_count=0
-        )
+    # Check if mock mode is enabled - DISABLED for now to show real users
+    # if settings.ADMIN_USERS_MOCK:
+    #     logger.warning("⚠️ ADMIN_USERS_MOCK is enabled - returning mock data. This should NOT be used in production!")
+    #     return UserListResponse(
+    #         users=[],
+    #         total_count=0,
+    #         active_count=0,
+    #         trading_count=0
+    #     )
     
     try:
         # Build the base query using select statement for async

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -150,9 +150,6 @@ class Settings(BaseSettings):
     COINGECKO_API_KEY: Optional[str] = Field(default=None, env="COINGECKO_API_KEY", description="CoinGecko API key")
     FINNHUB_API_KEY: Optional[str] = Field(default=None, env="FINNHUB_API_KEY", description="Finnhub API key")
     
-    # Admin settings
-    ADMIN_USERS_MOCK: bool = Field(default=False, env="ADMIN_USERS_MOCK", description="Enable mock admin users response (for testing only)")
-    
     # OAuth settings
     GOOGLE_CLIENT_ID: Optional[str] = Field(default=None, description="Google OAuth client ID")
     GOOGLE_CLIENT_SECRET: Optional[str] = Field(default=None, description="Google OAuth client secret")


### PR DESCRIPTION
## Summary
- Disabled ADMIN_USERS_MOCK check in admin.py endpoint
- This allows real users to be fetched from database in admin panel
- The mock mode was preventing the admin panel from displaying actual user data

## Test plan
- [ ] Start the backend server
- [ ] Login as admin user
- [ ] Navigate to admin panel
- [ ] Click on Users tab
- [ ] Verify that users from database are displayed

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin Users list now consistently returns real user records and correct totals across environments, removing an intermittent mock path that could show empty results. Public API and response format unchanged.

* **Chores**
  * Removed legacy mock configuration and shortcut to enforce uniform data retrieval and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->