### PR TITLE
Fix password validation to match backend requirements

### DIFF
--- a/frontend/src/components/auth/RegistrationForm.tsx
+++ b/frontend/src/components/auth/RegistrationForm.tsx
@@ -13,7 +13,11 @@ import { apiClient } from '@/lib/api/client';
 const formSchema = z.object({
   full_name: z.string().min(2, 'Full name must be at least 2 characters'),
   email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  password: z.string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+    .regex(/[0-9]/, 'Password must contain at least one number'),
   confirm_password: z.string(),
   terms_agreed: z.boolean().refine((val) => val === true, {
     message: 'You must agree to the terms of service',
@@ -146,6 +150,9 @@ export default function RegistrationForm() {
             data-testid="password-input"
             disabled={isLoading}
           />
+          <p className="text-xs text-muted-foreground">
+            Password must be at least 8 characters with uppercase, lowercase, and number
+          </p>
           {errors.password && (
             <p className="text-sm text-destructive" data-testid="password-error">
               {errors.password.message}


### PR DESCRIPTION
- Add frontend validation for password complexity requirements
- Password must contain uppercase, lowercase, and number
- Added user-friendly help text showing password requirements
- This resolves 422 validation error during registration

Frontend validation now matches backend RegisterRequest validation:
- Minimum 8 characters
- At least 1 uppercase letter (A-Z)
- At least 1 lowercase letter (a-z)
- At least 1 number (0-9)

🤖 Generated with [Claude Code](https://claude.ai/code)