### PR TITLE
Fix registration 422 error: Use lowercase role value

### DIFF
--- a/frontend/src/components/auth/RegistrationForm.tsx
+++ b/frontend/src/components/auth/RegistrationForm.tsx
@@ -58,7 +58,7 @@ export default function RegistrationForm() {
         email: data.email,
         password: data.password,
         full_name: data.full_name,
-        role: 'TRADER' // Default role
+        role: 'trader' // Backend expects lowercase role
       };
 
       // Debug logging (dev only) - mask sensitive data
@@ -100,11 +100,6 @@ export default function RegistrationForm() {
         // Handle 422 validation errors specifically
         if (err.response?.status === 422 && err.response?.data?.detail) {
           const validationErrors = err.response.data.detail;
-          
-          // TEMPORARY: Force log validation errors for debugging (will remove after fix)
-          console.error('=== REGISTRATION VALIDATION ERROR DEBUG ===');
-          console.error('Full validation errors:', validationErrors);
-          console.error('=== END DEBUG ===');
           
           // Dev-only: log validation error details (safe metadata only)
           if (import.meta.env.DEV) {


### PR DESCRIPTION
- Changed role from 'TRADER' to 'trader' to match backend enum expectation
- Backend expects lowercase role values: 'admin', 'trader', 'viewer', 'api_only'
- Removed temporary debug logging as issue is now identified and fixed
- Registration should now work successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved registration issue by sending the user role in the expected format, preventing errors for users selecting the Trader role.

* **Chores**
  * Cleaned up temporary debug logging in validation error handling to streamline internal diagnostics without affecting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->