### PR TITLE
fix: Use UserRole enum instead of string literals in AdminPage

### DIFF
--- a/frontend/src/pages/dashboard/AdminPage.tsx
+++ b/frontend/src/pages/dashboard/AdminPage.tsx
@@ -45,6 +45,7 @@ import { adminService } from '@/services/adminService';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/store/authStore';
 import { useNavigate } from 'react-router-dom';
+import { UserRole } from '@/types/auth';
 
 // State for real data
 interface User {
@@ -135,7 +136,7 @@ const AdminPage: React.FC = () => {
     }
     
     // Check if user has admin role
-    if (user.role !== 'admin' && user.role !== 'ADMIN') {
+    if (user.role !== UserRole.ADMIN) {
       toast.error('Access denied. Admin privileges required.');
       navigate('/dashboard');
       return;
@@ -145,7 +146,7 @@ const AdminPage: React.FC = () => {
   // Fetch real data from backend
   useEffect(() => {
     // Only fetch data if authenticated and authorized
-    if (isAuthenticated && user && (user.role === 'admin' || user.role === 'ADMIN')) {
+    if (isAuthenticated && user && user.role === UserRole.ADMIN) {
       fetchData();
     }
   }, [isAuthenticated, user]);
@@ -261,7 +262,7 @@ const AdminPage: React.FC = () => {
   }
 
   // Show access denied for non-admin users
-  if (user.role !== 'admin' && user.role !== 'ADMIN') {
+  if (user.role !== UserRole.ADMIN) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="text-center">


### PR DESCRIPTION
🔧 TypeScript Fix:
- Import UserRole enum from @/types/auth
- Replace string literals 'admin'/'ADMIN' with UserRole.ADMIN
- Fix TypeScript compilation errors for role comparisons

Build Error Fixed:
error TS2367: This comparison appears to be unintentional because the types 'UserRole.TRADER | UserRole.VIEWER | UserRole.API_ONLY' and '"ADMIN"' have no overlap.

Changes:
- user.role !== 'ADMIN' → user.role !== UserRole.ADMIN
- Consistent enum usage throughout component
- Type-safe role checking

This ensures proper TypeScript compilation and type safety for user role validation in the admin panel.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized admin permission validation across the Admin dashboard with a unified check. This improves consistency and reduces the risk of incorrect access gating during authorization, data loading, and rendering. No UI changes or user-facing behavior differences are expected; non-admin users remain blocked from admin content as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->