### PR TITLE
fix: Add type casting for config.metadata to fix TypeScript build errors

### DIFF
--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -12,7 +12,7 @@ const adminApi = axios.create({
 // Add auth token to requests
 adminApi.interceptors.request.use((config) => {
   // Set start time for duration tracking
-  config.metadata = { startTime: Date.now() };
+  (config as any).metadata = { startTime: Date.now() };
   
   const token = getAuthToken();
   if (token) {
@@ -45,7 +45,7 @@ adminApi.interceptors.request.use((config) => {
 adminApi.interceptors.response.use((response) => {
   // Only log minimal metadata in debug mode
   if (DEBUG_HTTP) {
-    const duration = Date.now() - (response.config.metadata?.startTime || Date.now());
+    const duration = Date.now() - ((response.config as any).metadata?.startTime || Date.now());
     console.debug('Admin API Response:', {
       method: response.config.method?.toUpperCase(),
       url: response.config.url,
@@ -59,7 +59,7 @@ adminApi.interceptors.response.use((response) => {
 }, (error) => {
   // Sanitized error logging
   if (DEBUG_HTTP) {
-    const duration = Date.now() - (error.config?.metadata?.startTime || Date.now());
+    const duration = Date.now() - ((error.config as any)?.metadata?.startTime || Date.now());
     console.debug('Admin API Error:', {
       method: error.config?.method?.toUpperCase(),
       url: error.config?.url,


### PR DESCRIPTION
- Cast config to any when setting metadata.startTime
- Cast response.config and error.config when reading metadata
- Fixes TypeScript compilation errors on Render deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated internal handling of request/response timing metadata to improve type compatibility and stability. No changes to behavior or user-facing functionality.
- Chores
  - Preserved existing timing calculations and debug logging to maintain consistent monitoring.
  - Minor internal cleanup to reduce type-related warnings and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->