### PR TITLE
fix: Resolve Date type mismatch in client.ts

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -44,7 +44,7 @@ apiClient.interceptors.request.use(
     }
 
     // Add request timestamp for debugging
-    config.metadata = { startTime: new Date() };
+    (config as any).metadata = { startTime: Date.now() };
     
     return config;
   },
@@ -58,9 +58,9 @@ apiClient.interceptors.response.use(
   (response: AxiosResponse) => {
     // Log response time in development
     if (import.meta.env.DEV) {
-      const startTime = response.config.metadata?.startTime;
+      const startTime = (response.config as any).metadata?.startTime;
       if (startTime) {
-        const duration = new Date().getTime() - startTime.getTime();
+        const duration = Date.now() - startTime;
         // API request timing logged internally
       }
     }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -44,7 +44,7 @@ apiClient.interceptors.request.use(
     }
 
     // Add request timestamp for debugging
-    (config as any).metadata = { startTime: Date.now() };
+    config.metadata = { ...(config.metadata || {}), startTime: Date.now() };
     
     return config;
   },
@@ -58,7 +58,7 @@ apiClient.interceptors.response.use(
   (response: AxiosResponse) => {
     // Log response time in development
     if (import.meta.env.DEV) {
-      const startTime = (response.config as any).metadata?.startTime;
+      const startTime = response.config.metadata?.startTime;
       if (startTime) {
         const duration = Date.now() - startTime;
         // API request timing logged internally
@@ -359,11 +359,4 @@ export type APIError = {
   data?: any;
 };
 
-// Declare module augmentation for metadata
-declare module 'axios' {
-  interface AxiosRequestConfig {
-    metadata?: {
-      startTime: Date;
-    };
-  }
-}
+// Module augmentation moved to src/types/axios.d.ts

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -12,7 +12,7 @@ const adminApi = axios.create({
 // Add auth token to requests
 adminApi.interceptors.request.use((config) => {
   // Set start time for duration tracking
-  (config as any).metadata = { startTime: Date.now() };
+  config.metadata = { ...(config.metadata || {}), startTime: Date.now() };
   
   const token = getAuthToken();
   if (token) {
@@ -45,7 +45,7 @@ adminApi.interceptors.request.use((config) => {
 adminApi.interceptors.response.use((response) => {
   // Only log minimal metadata in debug mode
   if (DEBUG_HTTP) {
-    const duration = Date.now() - ((response.config as any).metadata?.startTime || Date.now());
+    const duration = Date.now() - (response.config.metadata?.startTime || Date.now());
     console.debug('Admin API Response:', {
       method: response.config.method?.toUpperCase(),
       url: response.config.url,
@@ -59,7 +59,7 @@ adminApi.interceptors.response.use((response) => {
 }, (error) => {
   // Sanitized error logging
   if (DEBUG_HTTP) {
-    const duration = Date.now() - ((error.config as any)?.metadata?.startTime || Date.now());
+    const duration = Date.now() - (error.config?.metadata?.startTime || Date.now());
     console.debug('Admin API Error:', {
       method: error.config?.method?.toUpperCase(),
       url: error.config?.url,

--- a/frontend/src/types/axios.d.ts
+++ b/frontend/src/types/axios.d.ts
@@ -4,6 +4,7 @@ declare module 'axios' {
   export interface InternalAxiosRequestConfig {
     metadata?: {
       startTime?: number;
+      [key: string]: any; // Allow other metadata properties
     };
   }
 }

--- a/frontend/src/types/axios.d.ts
+++ b/frontend/src/types/axios.d.ts
@@ -1,10 +1,18 @@
 import 'axios';
 
 declare module 'axios' {
+  // Shared metadata interface
+  interface Metadata {
+    startTime?: number;
+    [key: string]: unknown; // Use unknown for type safety
+  }
+
+  // Augment both config types
+  export interface AxiosRequestConfig {
+    metadata?: Metadata;
+  }
+
   export interface InternalAxiosRequestConfig {
-    metadata?: {
-      startTime?: number;
-      [key: string]: any; // Allow other metadata properties
-    };
+    metadata?: Metadata;
   }
 }


### PR DESCRIPTION
- Changed startTime from Date object to number (timestamp)
- Use Date.now() instead of new Date() for consistency
- Fixed duration calculation to work with number type
- Add type casting for config.metadata

Fixes TypeScript build error on Render deployment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized request timing to use numeric timestamps for start/duration calculations.
  * Streamlined how request metadata is merged to preserve existing metadata fields.

* **Chores**
  * Moved and extended type declarations to allow flexible metadata keys.
  * Development-only request-duration logging remains unchanged for production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->