### PR TITLE
Fix login 500 error - remove role_normalizer import from auth endpoint

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -301,9 +301,7 @@ async def login(
             )
         
         # Check user status and verification
-        from app.utils.role_normalizer import normalize_status as norm_status
-        user_status = norm_status(user.status)
-        if user_status == UserStatus.PENDING_VERIFICATION:
+        if user.status == UserStatus.PENDING_VERIFICATION:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account pending admin verification. Please wait for admin approval to login."
@@ -313,7 +311,7 @@ async def login(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Account not verified. Please contact admin for verification."
             )
-        elif user_status != UserStatus.ACTIVE:
+        elif user.status != UserStatus.ACTIVE:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Account is {user.status.value}. Please contact admin."


### PR DESCRIPTION
- Removed problematic role_normalizer import that was causing 500 errors
- Reverted to direct enum comparison for user status checks
- This fixes the authentication service error preventing login
- Users can now login properly and access admin panel

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected login status evaluation to use the actual account status, improving accuracy when determining access.
  - Ensures accounts pending verification are consistently blocked from logging in.
  - Prevents non-active accounts from being incorrectly treated as active.
  - Reduces edge cases where users might be mistakenly allowed or denied access based on derived statuses.
  - Improves consistency of authentication outcomes across different account states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->