### PR TITLE
Enhance CORS helper for generic Response types and expose auth headers

### DIFF
--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -46,12 +46,12 @@ PROTECTED_PATHS = {
 TOKEN_REFRESH_THRESHOLD = 300
 
 
-def add_cors_headers_to_response(response: JSONResponse, request: Request) -> None:
+def add_cors_headers_to_response(response: Response, request: Request) -> None:
     """
     Add proper CORS headers to error responses with origin allowlist validation.
     
     Args:
-        response: The JSONResponse to add headers to
+        response: The Response to add headers to (can be any starlette.Response type)
         request: The incoming request to get Origin from
     """
     settings = get_settings()
@@ -67,11 +67,15 @@ def add_cors_headers_to_response(response: JSONResponse, request: Request) -> No
         response.headers["Access-Control-Allow-Origin"] = "*"
         # Don't set credentials header for non-allowed origins
     
-    # Append "Origin" to existing Vary header instead of replacing
+    # Append "Origin" to existing Vary header with proper parsing
     existing_vary = response.headers.get("Vary", "")
     if existing_vary:
-        if "Origin" not in existing_vary:
-            response.headers["Vary"] = f"{existing_vary}, Origin"
+        # Split existing vary header by commas and trim whitespace
+        tokens = [t.strip() for t in existing_vary.split(",")]
+        # Add "Origin" only if not already present
+        if "Origin" not in tokens:
+            tokens.append("Origin")
+        response.headers["Vary"] = ", ".join(tokens)
     else:
         response.headers["Vary"] = "Origin"
     

--- a/backend_simple.py
+++ b/backend_simple.py
@@ -62,6 +62,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-New-Access-Token"],  # Expose auth header for frontend
 )
 
 # Security

--- a/main.py
+++ b/main.py
@@ -315,7 +315,7 @@ def create_application() -> FastAPI:
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
         allow_headers=["*"],
-        expose_headers=["*"],
+        expose_headers=["X-New-Access-Token", "*"],  # Explicitly expose auth header
         max_age=86400  # Cache preflight for 24 hours
     )
     

--- a/main.py
+++ b/main.py
@@ -315,7 +315,13 @@ def create_application() -> FastAPI:
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
         allow_headers=["*"],
-        expose_headers=["X-New-Access-Token", "*"],  # Explicitly expose auth header
+        expose_headers=[
+            "X-New-Access-Token",     # For automatic token refresh
+            "X-Request-ID",          # For request tracking
+            "X-RateLimit-Limit",     # Rate limiting info
+            "X-RateLimit-Remaining", # Rate limiting info
+            "X-RateLimit-Reset"      # Rate limiting info
+        ],
         max_age=86400  # Cache preflight for 24 hours
     )
     


### PR DESCRIPTION
Improvements to CORS handling:
- Updated add_cors_headers_to_response to accept any starlette.Response type
- Enhanced Vary header parsing to properly split by commas and trim tokens
- Only add "Origin" to Vary if not already present, then rejoin cleanly
- Added X-New-Access-Token to expose_headers in both main.py and backend_simple.py
- Maintains existing Cache-Control and credential logic for security

This allows the frontend to read the X-New-Access-Token header for automatic token refresh and works with any response type.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Frontend can now read X-New-Access-Token plus request-tracking and rate-limit headers (X-Request-ID, X-RateLimit-*) via updated CORS exposure, improving token refresh and observability.

* Bug Fixes
  * Improved Vary header handling to avoid duplicates and ensure correct caching for CORS responses.
  * CORS semantics and no-store cache behavior preserved for allowed and wildcard origins.

* Chores
  * Broadened CORS response handling to accept generic response types without breaking existing integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->