### PR TITLE
Fix admin panel authentication by standardizing role validation

### DIFF
--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -133,7 +133,7 @@ class UserListResponse(BaseModel):
 # Admin Endpoints
 @router.get("/system/status")
 async def get_system_overview(
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Get comprehensive system status overview."""
@@ -200,7 +200,7 @@ async def get_system_overview(
 async def configure_system(
     request: SystemConfigRequest,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Configure system-wide settings."""
@@ -482,7 +482,7 @@ async def update_strategy_pricing(
 @router.get("/users/pending-verification")
 async def get_pending_verification_users(
     include_unverified: bool = False,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Get all users pending verification.
@@ -579,7 +579,7 @@ async def list_users(
     status_filter: Optional[str] = None,
     role_filter: Optional[str] = None,
     search: Optional[str] = None,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """List and filter users."""
@@ -753,7 +753,7 @@ async def list_users(
 @router.post("/users/verify/{user_id}")
 async def verify_user(
     user_id: str,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Verify a pending user account to allow login."""
@@ -887,7 +887,7 @@ async def verify_user(
 @router.post("/users/verify-batch")
 async def verify_users_batch(
     request: BatchVerifyRequest,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Verify multiple pending user accounts at once."""
@@ -1064,7 +1064,7 @@ async def verify_users_batch(
 @router.post("/users/manage")
 async def manage_user(
     request: UserManagementRequest,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Manage user accounts (activate, deactivate, etc.)."""
@@ -1199,7 +1199,7 @@ async def manage_user(
 
 @router.get("/metrics", response_model=SystemMetricsResponse)
 async def get_detailed_metrics(
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Get detailed system metrics."""
@@ -1283,7 +1283,7 @@ async def get_audit_logs(
     action_filter: Optional[str] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Get audit logs for security and compliance."""
@@ -1391,7 +1391,7 @@ async def get_audit_logs(
 @router.post("/emergency/stop-all")
 async def emergency_stop_all_trading(
     reason: str,
-    current_user: User = Depends(require_role(["ADMIN", UserRole.ADMIN])),
+    current_user: User = Depends(require_role([UserRole.ADMIN])),
     db: AsyncSession = Depends(get_database)
 ):
     """Emergency stop all trading across the platform."""


### PR DESCRIPTION
- Fixed inconsistent role checking in admin endpoints causing 401 errors
- Replaced mixed ["ADMIN", UserRole.ADMIN] with consistent [UserRole.ADMIN]
- All admin endpoints now use proper UserRole.ADMIN enum validation
- This resolves admin panel users list and other admin API 401 failures

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tightened access control on admin endpoints to require the Admin role exclusively.
  - Prevents unintended access from users relying on deprecated/legacy role identifiers.
  - No changes to endpoint behavior, responses, or UI.
  - Users without the Admin role may lose access to admin actions until their role is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->