### PR TITLE
Fix Google OAuth signup by adding OAuth endpoints to auth skip list

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -34,7 +34,10 @@ apiClient.interceptors.request.use(
       '/auth/reset-password',
       '/auth/verify-email',
       '/auth/refresh',
-      '/auth/logout'
+      '/auth/logout',
+      '/auth/oauth',
+      '/auth/oauth/url',
+      '/auth/oauth/callback'
     ];
 
     const shouldSkipAuth = skipAuthEndpoints.some(endpoint => 


### PR DESCRIPTION
- Added /auth/oauth, /auth/oauth/url, /auth/oauth/callback to skipAuthEndpoints
- This prevents axios interceptor from requiring authentication for OAuth signup flows
- Resolves 'No access token available' and 'Authentication required' errors on register page

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issues causing OAuth sign-in, authorization URL retrieval, and callback flows to fail by preventing unintended Authorization headers and token refresh attempts on these routes.
  * Ensures logout and OAuth steps proceed without requiring an active session, reducing redirect loops and authentication errors.
  * Improves reliability and compatibility of third-party sign-in across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->