### PR TITLE
Fix admin panel verify button logic to match backend validation

### DIFF
--- a/frontend/src/pages/dashboard/AdminPage.tsx
+++ b/frontend/src/pages/dashboard/AdminPage.tsx
@@ -764,7 +764,7 @@ const AdminPage: React.FC = () => {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        {(user.status === 'pending_verification' || !user.is_verified) && (
+                        {user.status === 'pending_verification' && (
                           <DropdownMenuItem onClick={() => handleVerifyUser(user.id)}>
                             <UserCheck className="mr-2 h-4 w-4 text-green-500" />
                             Verify User


### PR DESCRIPTION
- Only show "Verify User" button for users with pending_verification status
- Removes verify option for suspended/inactive users that can't be verified
- Use "Activate User" instead for suspended users that need reactivation
- Fixes API 400 errors when trying to verify non-pending users

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Verify User" action in the Admin dashboard now appears only for accounts with status "Pending verification."
  * It no longer shows for users who are simply unverified without that status.
  * This clarifies which accounts are eligible for verification and reduces noise in the menu.
  * Other dropdown items and behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->