### PR TITLE
Fix portfolio widget data loading and navigation

### DIFF
--- a/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
+++ b/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import {
   ChevronDown,
   ChevronUp,
@@ -39,9 +40,10 @@ interface CreditInfo {
 }
 
 const SophisticatedHeaderWidgets: React.FC = () => {
+  const navigate = useNavigate();
   const { isPaperMode, paperStats, paperBalance } = useGlobalPaperModeStore();
   const { exchanges, aggregatedStats } = useExchanges();
-  const { totalValue, dailyPnL, totalPnL, positions } = usePortfolioStore();
+  const { totalValue, dailyPnL, totalPnL, positions, fetchPortfolio, fetchStatus, fetchMarketData } = usePortfolioStore();
 
   // Credits query
   const { data: credits } = useQuery({
@@ -52,6 +54,13 @@ const SophisticatedHeaderWidgets: React.FC = () => {
     },
     refetchInterval: 30000
   });
+
+  // Fetch portfolio data on component mount
+  useEffect(() => {
+    fetchPortfolio();
+    fetchStatus();
+    fetchMarketData();
+  }, [fetchPortfolio, fetchStatus, fetchMarketData]);
 
   // Calculate portfolio metrics
   const portfolioValue = isPaperMode ? paperBalance : totalValue;
@@ -155,7 +164,12 @@ const SophisticatedHeaderWidgets: React.FC = () => {
               )}
 
               <Separator />
-              <Button variant="outline" size="sm" className="w-full">
+              <Button 
+                variant="outline" 
+                size="sm" 
+                className="w-full"
+                onClick={() => navigate('/dashboard/portfolio')}
+              >
                 View Full Portfolio
               </Button>
             </CardContent>


### PR DESCRIPTION
- Add useEffect to fetch portfolio data on component mount
- Fix "View Full Portfolio" button to navigate to portfolio page
- Import useNavigate and add onClick handler for navigation
- Ensure real portfolio data loads instead of showing hardcoded zeros

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - “View Full Portfolio” button now takes you directly to the portfolio dashboard from the header.

- Improvements
  - Header widgets automatically load portfolio, account status, and market data on first view for more up-to-date figures.
  - More reliable display of total value and PnL due to expanded data fetching.
  - Reduced need for manual refresh, providing a smoother, faster overview experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->