### PR TITLE
Fix header dropdown Manage Exchanges navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import StrategyMarketplace from '@/pages/dashboard/StrategyMarketplace';
 import PerformanceHub from '@/pages/dashboard/PerformanceHub';
 import CopyTradingNetwork from '@/pages/dashboard/CopyTradingNetwork';
 import PortfolioPage from '@/pages/dashboard/PortfolioPage';
+import ExchangesPage from '@/pages/dashboard/ExchangesPage';
 import SettingsPage from '@/pages/dashboard/SettingsPage';
 import AdminPage from '@/pages/dashboard/AdminPage';
 
@@ -137,6 +138,9 @@ const App: React.FC = () => {
               
               {/* Portfolio */}
               <Route path="portfolio" element={<PortfolioPage />} />
+              
+              {/* Exchanges */}
+              <Route path="exchanges" element={<ExchangesPage />} />
               
               {/* Settings */}
               <Route path="settings" element={<SettingsPage />} />

--- a/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
+++ b/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
@@ -265,7 +265,12 @@ const SophisticatedHeaderWidgets: React.FC = () => {
               )}
 
               <Separator />
-              <Button variant="outline" size="sm" className="w-full">
+              <Button 
+                variant="outline" 
+                size="sm" 
+                className="w-full"
+                onClick={() => navigate('/dashboard/exchanges')}
+              >
                 Manage Exchanges
               </Button>
             </CardContent>


### PR DESCRIPTION
- Added onClick handler to Manage Exchanges button to navigate to /dashboard/exchanges
- Added missing exchanges route and ExchangesPage import to App.tsx
- Fixes "Manage Exchanges" button not working in header exchanges dropdown

Note: "84 Trades Today" is calculated from real API (sum of trades_24h from exchanges) The backend exchanges API may be returning static trades_24h values that need updating

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Exchanges page to the dashboard, accessible to signed-in users.
  * Integrated the Exchanges page into existing dashboard navigation.

* **Bug Fixes**
  * The “Manage Exchanges” button now correctly navigates to the Exchanges page instead of doing nothing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->