### PR TITLE
Remove admin panel button from header widgets

### DIFF
--- a/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
+++ b/frontend/src/components/layout/SophisticatedHeaderWidgets.tsx
@@ -370,26 +370,6 @@ const SophisticatedHeaderWidgets: React.FC = () => {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Admin Indicator */}
-      {user?.role === UserRole.ADMIN && (
-        <>
-          <Separator orientation="vertical" className="h-8" />
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex items-center gap-2 px-3 py-2 h-auto border-yellow-500/30 text-yellow-600 hover:bg-yellow-500/10"
-            onClick={() => navigate('/dashboard/admin')}
-          >
-            <div className="flex items-center gap-2">
-              <Activity className="h-4 w-4" />
-              <div className="flex flex-col items-start">
-                <span className="text-sm font-semibold">Admin</span>
-                <span className="text-xs text-muted-foreground">Panel</span>
-              </div>
-            </div>
-          </Button>
-        </>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
- Remove unnecessary admin panel quick access button from header
- Clean up header layout to reduce clutter
- Admin access still available via sidebar navigation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the Admin Panel shortcut from the header. Admin users will no longer see the “Admin Panel” button or its separator in the header.
  - Balance dropdown, exchange connections, and credits widgets remain unchanged.
  - No changes for non-admin users; overall header functionality is unaffected aside from the removed admin-specific control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->