### PR TITLE
Fix Telegram connection rate limiting and improve reconnection flow

### DIFF
--- a/frontend/src/components/TelegramConnectionModal.tsx
+++ b/frontend/src/components/TelegramConnectionModal.tsx
@@ -84,10 +84,14 @@ const TelegramConnectionModal: React.FC<TelegramConnectionModalProps> = ({
       
       // Show more specific error messages
       let errorMessage = "Failed to create Telegram connection";
-      if (error.response?.status === 400) {
+      if (error.response?.status === 429) {
+        errorMessage = "Too many connection attempts. Please wait a minute before trying again.";
+      } else if (error.response?.status === 400) {
         errorMessage = error.response.data?.detail || "Connection already exists or invalid configuration";
       } else if (error.response?.status === 500) {
         errorMessage = "Server error - please try again later";
+      } else if (error.message?.includes("Rate limit exceeded")) {
+        errorMessage = "Rate limit exceeded. Please wait a moment before trying again.";
       } else if (error.message) {
         errorMessage = error.message;
       }


### PR DESCRIPTION
## Rate Limiting Fixes
- Increase rate limit from 5 to 10 connections per window
- Reduce rate limit window from 5 minutes to 1 minute for better UX
- Add specific 429 error handling in frontend modal

## Connection Flow Improvements
- Allow reconnection when existing connection is in pending state
- Automatically clean up pending connections to avoid duplicates
- Better error messages for authenticated vs pending connection states
- Enhanced error handling for rate limit scenarios

## User Experience
- Users no longer blocked by overly strict rate limits
- Clear feedback when rate limits are hit with specific wait times
- Seamless reconnection flow for incomplete connections
- More helpful error messages throughout connection process

Resolves: Rate limit exceeded errors during connection testing

🤖 Generated with [Claude Code](https://claude.ai/code)