### PR TITLE
Improve Telegram username field with helpful user guidance

### DIFF
--- a/frontend/src/components/TelegramConnectionModal.tsx
+++ b/frontend/src/components/TelegramConnectionModal.tsx
@@ -175,9 +175,14 @@ const TelegramConnectionModal: React.FC<TelegramConnectionModalProps> = ({
                       }
                       className="bg-[#1a1c23] border-[#2a2d35] text-gray-200 placeholder:text-gray-500"
                     />
-                    <p className="text-sm text-gray-400 mt-1">
-                      Optional: Your Telegram username for identification
-                    </p>
+                    <div className="text-xs text-blue-300 bg-blue-500/10 border border-blue-500/20 rounded p-3 mt-2">
+                      <p className="font-medium mb-1">💡 How to find your Telegram info:</p>
+                      <ul className="space-y-1 list-disc list-inside text-blue-200/80">
+                        <li><strong>Username:</strong> Settings → Edit Profile → Username</li>
+                        <li><strong>User ID:</strong> Message @userinfobot to get your numeric ID</li>
+                        <li><strong>Alternative:</strong> Leave blank - we'll get it during authentication</li>
+                      </ul>
+                    </div>
                   </div>
 
                   {/* Feature Toggles */}


### PR DESCRIPTION
- Add comprehensive help section for finding Telegram username/user ID
- Include instructions for using @userinfobot to get numeric user ID
- Clarify that username is optional and will be captured during authentication
- Better visual guidance with info box design
- Improves user experience for connection setup

Makes it easier for users to understand what Telegram info they need

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Replaced the brief helper text under the Telegram Username field with a prominent, styled info block.
  - Added “How to find your Telegram info” with steps: locate Username (Settings → Edit Profile → Username), get User ID (message @userinfobot), or leave blank to fetch during authentication.
  - UI-only change; no impact on logic or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->