### PR TITLE
Fix Strategy Marketplace API endpoints - resolve 405 errors

### DIFF
--- a/frontend/src/pages/dashboard/StrategyMarketplace.tsx
+++ b/frontend/src/pages/dashboard/StrategyMarketplace.tsx
@@ -158,7 +158,7 @@ const StrategyMarketplace: React.FC = () => {
       params.append('sort_by', filters.sort_by);
       params.append('include_performance', 'true');
       
-      const response = await apiClient.get(`/marketplace/strategies?${params}`);
+      const response = await apiClient.get(`/strategies/marketplace?${params}`);
       return response.data.strategies as MarketplaceStrategy[];
     },
     refetchInterval: 60000, // Refresh every minute
@@ -180,7 +180,7 @@ const StrategyMarketplace: React.FC = () => {
   // Purchase strategy mutation
   const purchaseStrategyMutation = useMutation({
     mutationFn: async (strategyId: string) => {
-      const response = await apiClient.post(`/marketplace/strategies/${strategyId}/purchase`);
+      const response = await apiClient.post(`/strategies/purchase`, { strategy_id: strategyId });
       return response.data;
     },
     onSuccess: (data, strategyId) => {


### PR DESCRIPTION
- Change /marketplace/strategies to /strategies/marketplace (correct backend endpoint)
- Fix strategy purchase endpoint to use POST /strategies/purchase with strategy_id
- Match backend API structure that exists in strategies.py
- Marketplace should now load real data instead of showing API Error: 405

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Refactor
  - Updated API routes used by the Strategy Marketplace and purchase flow without altering functionality or UI.
- Chores
  - Aligned frontend requests with backend route restructuring to maintain compatibility.
- Notes
  - No changes to public interfaces, caching, or error handling; existing workflows continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->