### PR TITLE
fix: Make Need Credits button functional with proper navigation

### DIFF
--- a/frontend/src/pages/dashboard/StrategyMarketplace.tsx
+++ b/frontend/src/pages/dashboard/StrategyMarketplace.tsx
@@ -543,9 +543,13 @@ const StrategyMarketplace: React.FC = () => {
                       size="sm"
                       onClick={(e) => {
                         e.stopPropagation();
-                        handlePurchaseStrategy(strategy);
+                        if (!strategy.user_can_afford) {
+                          navigate('/dashboard/credits/purchase');
+                        } else {
+                          handlePurchaseStrategy(strategy);
+                        }
                       }}
-                      disabled={strategy.user_has_purchased || !strategy.user_can_afford || purchaseStrategyMutation.isPending}
+                      disabled={strategy.user_has_purchased || purchaseStrategyMutation.isPending}
                       className={strategy.user_has_purchased ? 'bg-green-500' : ''}
                     >
                       {strategy.user_has_purchased ? (
@@ -556,7 +560,10 @@ const StrategyMarketplace: React.FC = () => {
                       ) : purchaseStrategyMutation.isPending ? (
                         'Purchasing...'
                       ) : !strategy.user_can_afford ? (
-                        'Need Credits'
+                        <>
+                          <DollarSign className="h-4 w-4 mr-2" />
+                          Need Credits
+                        </>
                       ) : (
                         <>
                           <ShoppingCart className="h-4 w-4 mr-2" />


### PR DESCRIPTION
- Add navigation to /dashboard/credits/purchase when user can't afford strategy
- Remove disabled state for Need Credits button to allow click
- Add DollarSign icon to Need Credits button for better UX
- Keep disabled state only for owned strategies and during purchase

Resolves issue where Need Credits button was non-functional and users couldn't navigate to purchase credits page.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When you can’t afford a strategy, clicking “Purchase” now takes you to the credits purchase page.
  * Added a Dollar icon next to “Need Credits” on strategy cards for clearer status.

* **Bug Fixes**
  * Purchase buttons are no longer disabled due to insufficient credits; they only disable if already owned or while a purchase is in progress.
  * Strategy details modal keeps clear status labels while aligning button enabled/disabled behavior with the card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->