### PR TITLE
fix: Resolve TypeScript build errors in MyStrategies

### DIFF
--- a/frontend/src/pages/dashboard/MyStrategies.tsx
+++ b/frontend/src/pages/dashboard/MyStrategies.tsx
@@ -114,6 +114,16 @@ interface UserStrategyPortfolio {
   strategies: UserStrategy[];
 }
 
+// Type guard for error response
+const isErrorResponse = (obj: unknown): obj is { detail: string } => {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    'detail' in obj &&
+    typeof (obj as any).detail === 'string'
+  );
+};
+
 const MyStrategies: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -261,8 +271,14 @@ const MyStrategies: React.FC = () => {
       }
       // Other axios errors
       else {
-        const responseData = portfolioError.response?.data as any;
-        errorMessage = responseData?.detail || portfolioError.message;
+        const responseData = portfolioError.response?.data;
+        if (typeof responseData === 'string') {
+          errorMessage = responseData;
+        } else if (isErrorResponse(responseData)) {
+          errorMessage = responseData.detail;
+        } else {
+          errorMessage = portfolioError.message;
+        }
       }
     } else if (portfolioError && typeof portfolioError === 'object' && 'message' in portfolioError) {
       errorMessage = (portfolioError as Error).message;

--- a/frontend/src/pages/dashboard/MyStrategies.tsx
+++ b/frontend/src/pages/dashboard/MyStrategies.tsx
@@ -261,10 +261,11 @@ const MyStrategies: React.FC = () => {
       }
       // Other axios errors
       else {
-        errorMessage = portfolioError.response?.data?.detail || portfolioError.message;
+        const responseData = portfolioError.response?.data as any;
+        errorMessage = responseData?.detail || portfolioError.message;
       }
-    } else if (portfolioError instanceof Error) {
-      errorMessage = portfolioError.message;
+    } else if (portfolioError && typeof portfolioError === 'object' && 'message' in portfolioError) {
+      errorMessage = (portfolioError as Error).message;
     }
 
     return (


### PR DESCRIPTION
- Fix 'detail' property type error by casting response data
- Fix instanceof check with proper type guard
- Handle Error type checking safely for unknown errors

Fixes build errors:
- TS2339: Property 'detail' does not exist
- TS2358: instanceof expression type issue
- TS2339: Property 'message' does not exist

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent blank or misleading error messages on the My Strategies dashboard so users now see consistent, meaningful error text across varied server responses.

* **Refactor**
  * Improved client-side error handling to better interpret diverse error payloads, increasing resilience and reducing edge-case failures while preserving existing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->