### PR TITLE
Add real database support for Strategy Publisher

### DIFF
--- a/alembic/versions/add_strategy_submissions_table.py
+++ b/alembic/versions/add_strategy_submissions_table.py
@@ -1,0 +1,90 @@
+"""Add strategy submissions table
+
+Revision ID: add_strategy_submissions
+Revises:
+Create Date: 2025-01-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers
+revision = 'add_strategy_submissions'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create enum types
+    op.execute("CREATE TYPE strategystatus AS ENUM ('draft', 'submitted', 'under_review', 'approved', 'rejected', 'published', 'withdrawn')")
+    op.execute("CREATE TYPE pricingmodel AS ENUM ('free', 'one_time', 'subscription', 'profit_share')")
+    op.execute("CREATE TYPE risklevel AS ENUM ('low', 'medium', 'high')")
+    op.execute("CREATE TYPE complexitylevel AS ENUM ('beginner', 'intermediate', 'advanced')")
+    op.execute("CREATE TYPE supportlevel AS ENUM ('basic', 'standard', 'premium')")
+
+    # Create strategy_submissions table
+    op.create_table('strategy_submissions',
+        sa.Column('id', sa.String(36), nullable=False),
+        sa.Column('user_id', sa.String(36), nullable=False),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('category', sa.String(100), nullable=False),
+        sa.Column('risk_level', sa.Enum('low', 'medium', 'high', name='risklevel'), nullable=True),
+        sa.Column('expected_return_min', sa.Float(), nullable=True),
+        sa.Column('expected_return_max', sa.Float(), nullable=True),
+        sa.Column('required_capital', sa.DECIMAL(15, 2), nullable=True),
+        sa.Column('pricing_model', sa.Enum('free', 'one_time', 'subscription', 'profit_share', name='pricingmodel'), nullable=True),
+        sa.Column('price_amount', sa.DECIMAL(10, 2), nullable=True),
+        sa.Column('profit_share_percentage', sa.Float(), nullable=True),
+        sa.Column('status', sa.Enum('draft', 'submitted', 'under_review', 'approved', 'rejected', 'published', 'withdrawn', name='strategystatus'), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('submitted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('reviewed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('published_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('reviewer_id', sa.String(36), nullable=True),
+        sa.Column('reviewer_feedback', sa.Text(), nullable=True),
+        sa.Column('rejection_reason', sa.Text(), nullable=True),
+        sa.Column('backtest_results', sa.JSON(), nullable=True),
+        sa.Column('validation_results', sa.JSON(), nullable=True),
+        sa.Column('tags', sa.JSON(), nullable=True),
+        sa.Column('target_audience', sa.JSON(), nullable=True),
+        sa.Column('complexity_level', sa.Enum('beginner', 'intermediate', 'advanced', name='complexitylevel'), nullable=True),
+        sa.Column('documentation_quality', sa.Integer(), nullable=True),
+        sa.Column('support_level', sa.Enum('basic', 'standard', 'premium', name='supportlevel'), nullable=True),
+        sa.Column('strategy_code', sa.Text(), nullable=True),
+        sa.Column('strategy_config', sa.JSON(), nullable=True),
+        sa.Column('total_subscribers', sa.Integer(), nullable=True),
+        sa.Column('total_revenue', sa.DECIMAL(15, 2), nullable=True),
+        sa.Column('average_rating', sa.Float(), nullable=True),
+        sa.Column('total_reviews', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['reviewer_id'], ['users.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    # Create indexes for better query performance
+    op.create_index('idx_strategy_submissions_user_id', 'strategy_submissions', ['user_id'])
+    op.create_index('idx_strategy_submissions_status', 'strategy_submissions', ['status'])
+    op.create_index('idx_strategy_submissions_category', 'strategy_submissions', ['category'])
+    op.create_index('idx_strategy_submissions_created_at', 'strategy_submissions', ['created_at'])
+
+
+def downgrade():
+    # Drop indexes
+    op.drop_index('idx_strategy_submissions_created_at', 'strategy_submissions')
+    op.drop_index('idx_strategy_submissions_category', 'strategy_submissions')
+    op.drop_index('idx_strategy_submissions_status', 'strategy_submissions')
+    op.drop_index('idx_strategy_submissions_user_id', 'strategy_submissions')
+
+    # Drop table
+    op.drop_table('strategy_submissions')
+
+    # Drop enum types
+    op.execute("DROP TYPE IF EXISTS strategystatus")
+    op.execute("DROP TYPE IF EXISTS pricingmodel")
+    op.execute("DROP TYPE IF EXISTS risklevel")
+    op.execute("DROP TYPE IF EXISTS complexitylevel")
+    op.execute("DROP TYPE IF EXISTS supportlevel")

--- a/app/models/strategy_submission.py
+++ b/app/models/strategy_submission.py
@@ -1,0 +1,170 @@
+"""
+Strategy Submission Model for Publisher Dashboard
+
+This model handles strategy submissions from traders/publishers
+who want to list their strategies on the marketplace.
+"""
+
+from sqlalchemy import (
+    Column, String, Integer, Float, Boolean, Text, JSON,
+    DateTime, ForeignKey, Enum as SQLEnum, DECIMAL
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import enum
+from uuid import uuid4
+
+from app.core.database import Base
+
+
+class StrategyStatus(str, enum.Enum):
+    DRAFT = "draft"
+    SUBMITTED = "submitted"
+    UNDER_REVIEW = "under_review"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    PUBLISHED = "published"
+    WITHDRAWN = "withdrawn"
+
+
+class PricingModel(str, enum.Enum):
+    FREE = "free"
+    ONE_TIME = "one_time"
+    SUBSCRIPTION = "subscription"
+    PROFIT_SHARE = "profit_share"
+
+
+class RiskLevel(str, enum.Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class ComplexityLevel(str, enum.Enum):
+    BEGINNER = "beginner"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
+
+
+class SupportLevel(str, enum.Enum):
+    BASIC = "basic"
+    STANDARD = "standard"
+    PREMIUM = "premium"
+
+
+class StrategySubmission(Base):
+    __tablename__ = "strategy_submissions"
+
+    # Primary key
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+
+    # Foreign key to user (publisher)
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+
+    # Basic Information
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=False)
+    category = Column(String(100), nullable=False)
+    risk_level = Column(SQLEnum(RiskLevel), default=RiskLevel.MEDIUM)
+
+    # Financial Details
+    expected_return_min = Column(Float, default=0.0)
+    expected_return_max = Column(Float, default=0.0)
+    required_capital = Column(DECIMAL(15, 2), default=1000.0)
+
+    # Pricing
+    pricing_model = Column(SQLEnum(PricingModel), default=PricingModel.FREE)
+    price_amount = Column(DECIMAL(10, 2), nullable=True)
+    profit_share_percentage = Column(Float, nullable=True)
+
+    # Status
+    status = Column(SQLEnum(StrategyStatus), default=StrategyStatus.DRAFT)
+
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    submitted_at = Column(DateTime(timezone=True), nullable=True)
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
+    published_at = Column(DateTime(timezone=True), nullable=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    # Review Details
+    reviewer_id = Column(String(36), ForeignKey("users.id"), nullable=True)
+    reviewer_feedback = Column(Text, nullable=True)
+    rejection_reason = Column(Text, nullable=True)
+
+    # Backtest Results (stored as JSON)
+    backtest_results = Column(JSON, nullable=True, default={
+        "total_return": 0.0,
+        "sharpe_ratio": 0.0,
+        "max_drawdown": 0.0,
+        "win_rate": 0.0,
+        "total_trades": 0,
+        "profit_factor": 0.0,
+        "period_days": 0
+    })
+
+    # Validation Results (stored as JSON)
+    validation_results = Column(JSON, nullable=True, default={
+        "is_valid": False,
+        "security_score": 0,
+        "performance_score": 0,
+        "code_quality_score": 0,
+        "overall_score": 0
+    })
+
+    # Publishing Details
+    tags = Column(JSON, nullable=True, default=list)
+    target_audience = Column(JSON, nullable=True, default=list)
+    complexity_level = Column(SQLEnum(ComplexityLevel), default=ComplexityLevel.INTERMEDIATE)
+    documentation_quality = Column(Integer, default=0)
+    support_level = Column(SQLEnum(SupportLevel), default=SupportLevel.STANDARD)
+
+    # Strategy Code/Configuration (stored securely)
+    strategy_code = Column(Text, nullable=True)  # Encrypted in production
+    strategy_config = Column(JSON, nullable=True)
+
+    # Statistics
+    total_subscribers = Column(Integer, default=0)
+    total_revenue = Column(DECIMAL(15, 2), default=0.0)
+    average_rating = Column(Float, default=0.0)
+    total_reviews = Column(Integer, default=0)
+
+    # Relationships
+    user = relationship("User", foreign_keys=[user_id], backref="strategy_submissions")
+    reviewer = relationship("User", foreign_keys=[reviewer_id], backref="reviewed_strategies")
+
+    def to_dict(self):
+        """Convert model to dictionary for API responses."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "category": self.category,
+            "risk_level": self.risk_level.value if self.risk_level else "medium",
+            "expected_return_range": [
+                float(self.expected_return_min or 0),
+                float(self.expected_return_max or 0)
+            ],
+            "required_capital": float(self.required_capital or 1000),
+            "pricing_model": self.pricing_model.value if self.pricing_model else "free",
+            "price_amount": float(self.price_amount) if self.price_amount else None,
+            "profit_share_percentage": self.profit_share_percentage,
+            "status": self.status.value if self.status else "draft",
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "submitted_at": self.submitted_at.isoformat() if self.submitted_at else None,
+            "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "published_at": self.published_at.isoformat() if self.published_at else None,
+            "reviewer_feedback": self.reviewer_feedback,
+            "rejection_reason": self.rejection_reason,
+            "backtest_results": self.backtest_results or {},
+            "validation_results": self.validation_results or {},
+            "tags": self.tags or [],
+            "target_audience": self.target_audience or [],
+            "complexity_level": self.complexity_level.value if self.complexity_level else "intermediate",
+            "documentation_quality": self.documentation_quality or 0,
+            "support_level": self.support_level.value if self.support_level else "standard",
+            "total_subscribers": self.total_subscribers or 0,
+            "total_revenue": float(self.total_revenue or 0),
+            "average_rating": self.average_rating or 0,
+            "total_reviews": self.total_reviews or 0
+        }

--- a/app/models/strategy_submission.py
+++ b/app/models/strategy_submission.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+from sqlalchemy.ext.mutable import MutableDict
 import enum
 from uuid import uuid4
 
@@ -93,35 +94,43 @@ class StrategySubmission(Base):
     rejection_reason = Column(Text, nullable=True)
 
     # Backtest Results (stored as JSON)
-    backtest_results = Column(JSON, nullable=True, default={
-        "total_return": 0.0,
-        "sharpe_ratio": 0.0,
-        "max_drawdown": 0.0,
-        "win_rate": 0.0,
-        "total_trades": 0,
-        "profit_factor": 0.0,
-        "period_days": 0
-    })
+    backtest_results = Column(
+        MutableDict.as_mutable(JSON),
+        nullable=True,
+        default=lambda: {
+            "total_return": 0.0,
+            "sharpe_ratio": 0.0,
+            "max_drawdown": 0.0,
+            "win_rate": 0.0,
+            "total_trades": 0,
+            "profit_factor": 0.0,
+            "period_days": 0
+        }
+    )
 
     # Validation Results (stored as JSON)
-    validation_results = Column(JSON, nullable=True, default={
-        "is_valid": False,
-        "security_score": 0,
-        "performance_score": 0,
-        "code_quality_score": 0,
-        "overall_score": 0
-    })
+    validation_results = Column(
+        MutableDict.as_mutable(JSON),
+        nullable=True,
+        default=lambda: {
+            "is_valid": False,
+            "security_score": 0,
+            "performance_score": 0,
+            "code_quality_score": 0,
+            "overall_score": 0
+        }
+    )
 
     # Publishing Details
-    tags = Column(JSON, nullable=True, default=list)
-    target_audience = Column(JSON, nullable=True, default=list)
+    tags = Column(MutableDict.as_mutable(JSON), nullable=True, default=list)
+    target_audience = Column(MutableDict.as_mutable(JSON), nullable=True, default=list)
     complexity_level = Column(SQLEnum(ComplexityLevel), default=ComplexityLevel.INTERMEDIATE)
     documentation_quality = Column(Integer, default=0)
     support_level = Column(SQLEnum(SupportLevel), default=SupportLevel.STANDARD)
 
     # Strategy Code/Configuration (stored securely)
     strategy_code = Column(Text, nullable=True)  # Encrypted in production
-    strategy_config = Column(JSON, nullable=True)
+    strategy_config = Column(MutableDict.as_mutable(JSON), nullable=True, default=dict)
 
     # Statistics
     total_subscribers = Column(Integer, default=0)


### PR DESCRIPTION
Fixed Strategy Publisher to use real database instead of mock data:
- Created StrategySubmission database model with all required fields
- Added Alembic migration for strategy_submissions table
- Updated API endpoints to query real database
- Replaced mock data with actual database operations

Now Strategy Publisher will store and retrieve real user submissions.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Publishers can submit strategies for review with full details (pricing, risk, metadata) and receive a persistent submission ID.
  - View your submissions list backed by real data, showing status, timestamps, reviewer info, and key fields.

- Improvements
  - Submissions are now persisted in the database for reliability, accurate counts, and ordering by creation time.

- Chores
  - Database migration added to support strategy submissions and related attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->