### PR TITLE
Add missing Publisher Dashboard endpoints

### DIFF
--- a/app/api/v1/endpoints/strategies.py
+++ b/app/api/v1/endpoints/strategies.py
@@ -1266,12 +1266,11 @@ async def get_publisher_reviews(
         # Try to get real reviews from database
         try:
             # In a real implementation, you'd query a reviews table
-            # For now, we'll simulate with strategy submission data
+            # For now, we'll simulate with strategy submission data - exclude internal reviewer_feedback
             query = select(
                 StrategySubmission.name,
                 StrategySubmission.average_rating,
-                StrategySubmission.total_reviews,
-                StrategySubmission.reviewer_feedback
+                StrategySubmission.total_reviews
             ).where(
                 and_(
                     StrategySubmission.user_id == str(current_user.id),
@@ -1282,13 +1281,12 @@ async def get_publisher_reviews(
             result = await db.execute(query)
             reviews = result.fetchall()
 
-            # Format reviews data
+            # Format reviews data - only public-facing fields
             reviews_data = [
                 {
                     "strategy_name": review.name,
                     "average_rating": float(review.average_rating or 0),
-                    "total_reviews": review.total_reviews or 0,
-                    "latest_feedback": review.reviewer_feedback or "No feedback available"
+                    "total_reviews": review.total_reviews or 0
                 }
                 for review in reviews
             ]

--- a/frontend/src/pages/dashboard/PublisherDashboard.tsx
+++ b/frontend/src/pages/dashboard/PublisherDashboard.tsx
@@ -205,14 +205,19 @@ const PublisherDashboard: React.FC = () => {
     refetchInterval: 60000
   });
 
+  // Map payouts using only real backend fields, show "—" for missing data
   const payouts = payoutsData?.payouts?.map((payout: any, index: number) => ({
-    id: `payout-${index}`,
+    // Use backend id if available, otherwise show placeholder
+    id: payout.id || "—",
     amount: payout.amount,
     status: payout.status,
-    requested_at: payout.date,
-    processed_at: payout.status === 'completed' ? payout.date : undefined,
-    payment_method: payout.method || 'bank_transfer',
-    transaction_id: `tx-${index}`
+    // Map date fields from backend
+    requested_at: payout.date || payout.requested_at || "—",
+    processed_at: payout.processed_at || (payout.status === 'completed' ? payout.date : "—"),
+    // Use backend payment method or show placeholder
+    payment_method: payout.method || payout.payment_method || "—",
+    // Use backend transaction ID or show placeholder
+    transaction_id: payout.transaction_id || "—"
   })) || [];
 
   const COLORS = ['#22c55e', '#3b82f6', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'];
@@ -814,7 +819,7 @@ const PublisherDashboard: React.FC = () => {
                         </div>
                         <div className="text-xs text-muted-foreground mt-1">
                           {payout.payment_method}
-                          {payout.transaction_id && ` • ${payout.transaction_id}`}
+                          {payout.transaction_id && payout.transaction_id !== "—" && ` • ${payout.transaction_id}`}
                         </div>
                       </div>
                       

--- a/frontend/src/pages/dashboard/StrategyPublisher.tsx
+++ b/frontend/src/pages/dashboard/StrategyPublisher.tsx
@@ -443,11 +443,6 @@ const StrategyPublisher: React.FC = () => {
                           </div>
                         )}
 
-                        {submission.status === 'approved' && submission.reviewer_feedback && (
-                          <div className="p-2 bg-green-50 border border-green-200 rounded text-xs text-green-700">
-                            <strong>Reviewer Feedback:</strong> {submission.reviewer_feedback}
-                          </div>
-                        )}
 
                         {/* Requirements Check */}
                         {requirements && (


### PR DESCRIPTION
- Added /publisher/earnings-history endpoint with period filtering
- Added /publisher/strategy-earnings endpoint for strategy breakdown
- Added /publisher/reviews endpoint for strategy reviews
- Added /publisher/payouts endpoint for payout history
- All endpoints include real database queries with mock fallback
- Fixes 405 Method Not Allowed errors in Publisher Dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publisher analytics endpoints: earnings history, earnings by strategy, reviews overview, payout history, and submitted strategies listing; dashboard now consumes consolidated publisher endpoints under the strategies/publisher path.

* **Improvements**
  * Stronger validation for strategy submissions/updates and safer nested-configuration updates via deep-merge behavior.
  * Endpoints more resilient with graceful mock fallbacks, clearer errors, admin/trader access controls, and rate-limiting.

* **Changes**
  * Reviewer feedback for approved submissions removed from the publisher UI; Reviews Summary and payouts display updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->