### PR TITLE
Fix Strategy IDE frontend crashes after template selection

### DIFF
--- a/frontend/src/pages/dashboard/StrategyIDE.tsx
+++ b/frontend/src/pages/dashboard/StrategyIDE.tsx
@@ -204,7 +204,7 @@ const StrategyIDE: React.FC = () => {
   const validateStrategyMutation = useMutation({
     mutationFn: async (code: string) => {
       const response = await apiClient.post('/strategies/validate', { code });
-      return response.data as ValidationResult;
+      return response.data.validation_result as ValidationResult;
     },
     onSuccess: (result) => {
       setValidationResult(result);
@@ -213,7 +213,7 @@ const StrategyIDE: React.FC = () => {
       if (editorRef.current) {
         const model = editorRef.current.getModel();
         if (model) {
-          const markers = [...result.errors, ...result.warnings].map(issue => ({
+          const markers = [...(result.errors || []), ...(result.warnings || [])].map(issue => ({
             startLineNumber: issue.line,
             startColumn: issue.column,
             endLineNumber: issue.line,
@@ -752,7 +752,7 @@ const StrategyIDE: React.FC = () => {
                       </div>
                     </div>
                     
-                    {validationResult.errors.length > 0 && (
+                    {validationResult.errors && validationResult.errors.length > 0 && (
                       <div className="space-y-1">
                         <div className="text-sm font-medium text-red-600">Errors:</div>
                         {validationResult.errors.slice(0, 3).map((error, i) => (
@@ -762,8 +762,8 @@ const StrategyIDE: React.FC = () => {
                         ))}
                       </div>
                     )}
-                    
-                    {validationResult.warnings.length > 0 && (
+
+                    {validationResult.warnings && validationResult.warnings.length > 0 && (
                       <div className="space-y-1 mt-2">
                         <div className="text-sm font-medium text-yellow-600">Warnings:</div>
                         {validationResult.warnings.slice(0, 2).map((warning, i) => (


### PR DESCRIPTION
FRONTEND FIXES:
✅ Fixed API response parsing for validation endpoint ✅ Added null checks for errors/warnings arrays
✅ Fixed Monaco editor markers array access
✅ Proper handling of nested validation_result response

ROOT CAUSE:
- Backend returns: { success: true, validation_result: {...} }
- Frontend was expecting: { errors: [...], warnings: [...] }
- Arrays were undefined causing .length crashes

CHANGES:
- Updated validation mutation to use response.data.validation_result
- Added safe array checks: errors && errors.length > 0
- Protected Monaco markers with: [...(result.errors || []), ...]

Strategy IDE templates now load without crashes! ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with updated validation API responses, ensuring results load correctly.
  * Prevented crashes when validation returns no errors or warnings by safely handling missing fields.
  * Enhanced reliability of editor markers by accommodating empty or absent validation data.
  * Updated validation results overlay to render Errors and Warnings only when available, avoiding empty or broken sections.

* **Chores**
  * General stability improvements to the validation flow in the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->