### PR TITLE
Fix TypeScript error in A/B Testing Lab status checking

### DIFF
--- a/frontend/src/pages/dashboard/ABTestingLab.tsx
+++ b/frontend/src/pages/dashboard/ABTestingLab.tsx
@@ -346,8 +346,8 @@ const ABTestingLab: React.FC = () => {
                        testsStatus === 401 ||
                        metricsStatus === 500 ||
                        testsStatus === 500;
-    const isNotImplemented = [405, 404, 501].includes(metricsStatus) ||
-                          [405, 404, 501].includes(testsStatus);
+    const isNotImplemented = (metricsStatus && [405, 404, 501].includes(metricsStatus)) ||
+                          (testsStatus && [405, 404, 501].includes(testsStatus));
 
     return (
       <div className="p-6">


### PR DESCRIPTION
- Add null checks before using Array.includes() with status codes
- Prevent TypeError when metricsStatus or testsStatus is undefined
- Ensure type safety for getHttpStatus() return value usage
- Fixes build failure with TS2345 error about undefined not assignable to number

🤖 Generated with [Claude Code](https://claude.ai/code)