### PR TITLE
🚨 CRITICAL HOTFIX: IndentationError causing production outage

### DIFF
--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -902,8 +902,8 @@ class UserOpportunityDiscoveryService(LoggerMixin):
             
             for symbol in momentum_symbols:
                 try:
-                # User owns strategy - execute using unified approach
-                momentum_result = await trading_strategies_service.execute_strategy(
+                    # User owns strategy - execute using unified approach
+                    momentum_result = await trading_strategies_service.execute_strategy(
                     function="spot_momentum_strategy",
                     symbol=f"{symbol}/USDT",
                     parameters={"timeframe": "4h"},


### PR DESCRIPTION
## 🚨 CRITICAL PRODUCTION ISSUE

**Production deployment is completely down** - all workers failing to boot due to Python syntax error.

## Problem
```
IndentationError: expected an indented block after 'try' statement on line 904
File "/app/app/services/user_opportunity_discovery.py", line 906
```

**Impact:** Complete service outage - all Gunicorn workers crash on startup.

## Root Cause
- Missing indentation in `user_opportunity_discovery.py` at line 905-906
- Code inside `try` block not properly indented
- Prevents Python module import, breaking entire application startup

## Fix Applied ✅
```python
# Before (BROKEN):
for symbol in momentum_symbols:
    try:
    # User owns strategy - execute using unified approach  # ← Missing indent
    momentum_result = await trading_strategies_service.execute_strategy(  # ← Missing indent

# After (FIXED):
for symbol in momentum_symbols:
    try:
        # User owns strategy - execute using unified approach  # ← Proper indent
        momentum_result = await trading_strategies_service.execute_strategy(  # ← Proper indent
```

## Validation
- [x] Python syntax error resolved
- [x] Module imports successfully
- [x] Application can start without crashes

## Urgency: IMMEDIATE MERGE REQUIRED
This blocks all production deployments and causes complete service downtime.

---

**Request: Please merge immediately to restore service**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected indentation in internal logic to improve readability and maintain code style consistency. No changes to behavior or error handling.
- **Chores**
  - Minor code cleanup with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->