### PR TITLE
Fix AI Money Manager chat bot scroll functionality

### DIFF
--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   MessageSquare,
@@ -48,6 +48,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
   } = useChatStore();
   
   const [inputValue, setInputValue] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Initialize session when widget opens
   useEffect(() => {
@@ -56,6 +57,11 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
       initializeSession();
     }
   }, [isWidgetOpen]);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   const sendMessage = async () => {
     if (!inputValue.trim() || isLoading) return;
@@ -133,7 +139,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
               {!isWidgetMinimized && (
                 <CardContent className="flex flex-col p-0">
                   {/* Messages */}
-                  <ScrollArea className="flex-1 px-4 max-h-[calc(50vh-8rem)]">
+                  <ScrollArea className="flex-1 px-4 h-64 overflow-y-auto">
                     <div className="space-y-3 py-2">
                       {messages.map((message) => (
                         <div
@@ -191,6 +197,9 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
                           </div>
                         </div>
                       )}
+
+                      {/* Scroll anchor */}
+                      <div ref={messagesEndRef} />
                     </div>
                   </ScrollArea>
 


### PR DESCRIPTION
- Fixed ScrollArea height constraint from calc(50vh-8rem) to h-64 overflow-y-auto
- Added useRef for messages scroll anchor
- Added auto-scroll to bottom when new messages arrive
- Added scroll anchor div at end of messages for smooth scrolling
- Users can now scroll up to see older chat messages
- Latest messages automatically scroll into view

Fixes the issue where chat bot had no scroll bar making old messages inaccessible.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat now auto-scrolls smoothly to the latest message, keeping you at the bottom during new replies.
  * The chat area uses a fixed height with a scrollable view for long conversations, reducing layout shifts and improving readability.
  * Scrolling behavior is more consistent and reliable across message updates, enhancing navigation in lengthy threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->