### PR TITLE
Fix chat message overflow and container constraints

### DIFF
--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -103,7 +103,7 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
             exit={{ opacity: 0, scale: 0.8, y: 20 }}
             className={`fixed bottom-20 right-6 z-50 ${className}`}
           >
-            <Card className={`w-80 ${isWidgetMinimized ? 'h-14' : 'max-h-[50vh]'} transition-all duration-300 shadow-lg border bg-card/95 backdrop-blur-sm border-border/50`}>
+            <Card className={`w-80 ${isWidgetMinimized ? 'h-14' : 'h-96'} transition-all duration-300 shadow-lg border bg-card/95 backdrop-blur-sm border-border/50 overflow-hidden`}>
               {/* Header */}
               <CardHeader className="flex flex-row items-center justify-between space-y-0 py-3 px-4">
                 <div className="flex items-center gap-2">
@@ -137,9 +137,9 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
 
               {/* Chat Content */}
               {!isWidgetMinimized && (
-                <CardContent className="flex flex-col p-0">
+                <CardContent className="flex flex-col p-0 h-full overflow-hidden">
                   {/* Messages */}
-                  <ScrollArea className="flex-1 px-4 h-64 overflow-y-auto">
+                  <ScrollArea className="flex-1 px-4 min-h-0 max-h-full overflow-y-auto">
                     <div className="space-y-3 py-2">
                       {messages.map((message) => (
                         <div
@@ -153,13 +153,13 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ className = '' }) => {
                           )}
                           
                           <div
-                            className={`max-w-[85%] rounded-lg px-3 py-2 text-xs shadow-sm ${
+                            className={`max-w-[85%] rounded-lg px-3 py-2 text-xs shadow-sm break-words ${
                               message.type === 'user'
                                 ? 'bg-primary text-primary-foreground border border-primary/20'
                                 : 'bg-muted/90 backdrop-blur-sm'
                             }`}
                           >
-                            <div>{message.content}</div>
+                            <div className="break-words whitespace-pre-wrap">{message.content}</div>
                             <div className="flex items-center justify-between mt-1 gap-2">
                               <span className="text-xs opacity-70">
                                 {new Date(message.timestamp).toLocaleTimeString()}


### PR DESCRIPTION
- Fixed Card container height to h-96 with overflow-hidden
- Added proper height constraints to CardContent with h-full overflow-hidden
- Fixed ScrollArea to use flex layout with min-h-0 max-h-full
- Added break-words and whitespace-pre-wrap to prevent message text overflow
- Messages now properly wrap within chat container boundaries
- Scroll area now properly contained within chat widget bounds

Resolves message overflow outside chat box issue.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented content overflow and clipping issues in the chat widget.
  * Ensured long messages wrap correctly and preserve line breaks for better readability.
  * Improved scroll behavior so messages scroll within the available space.

* **Style**
  * Standardized chat widget heights for expanded and minimized states for more consistent layout.
  * Refined content sizing to fill the card cleanly without visual glitches.
  * Purely presentational changes; no functionality or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->