### PR TITLE
Handle strategy performance data quality correctly

### DIFF
--- a/app/models/market_data.py
+++ b/app/models/market_data.py
@@ -299,7 +299,18 @@ class StrategyPerformanceHistory(Base):
     @win_rate_fraction.setter
     def win_rate_fraction(self, value: float):
         """Set win rate from 0-1 fraction."""
-        self.win_rate = min(value * 100.0, 100.0)
+        from decimal import Decimal, ROUND_HALF_UP
+
+        # Clamp to valid range (0.0-1.0)
+        clamped_value = max(0.0, min(value, 1.0))
+
+        # Convert to percentage and then to Decimal with proper rounding
+        percentage = clamped_value * 100.0
+        decimal_percentage = Decimal(str(percentage)).quantize(
+            Decimal('0.01'), rounding=ROUND_HALF_UP
+        )
+
+        self.win_rate = float(decimal_percentage)
     
     @property
     def win_rate_percent(self) -> float:
@@ -309,7 +320,17 @@ class StrategyPerformanceHistory(Base):
     @win_rate_percent.setter
     def win_rate_percent(self, value: float):
         """Set win rate from 0-100 percentage."""
-        self.win_rate = min(value, 100.0)
+        from decimal import Decimal, ROUND_HALF_UP
+
+        # Clamp to valid range (0.0-100.0)
+        clamped_value = max(0.0, min(value, 100.0))
+
+        # Convert to Decimal with proper rounding
+        decimal_percentage = Decimal(str(clamped_value)).quantize(
+            Decimal('0.01'), rounding=ROUND_HALF_UP
+        )
+
+        self.win_rate = float(decimal_percentage)
 
 
 class BacktestResult(Base):

--- a/app/services/trade_execution.py
+++ b/app/services/trade_execution.py
@@ -658,8 +658,7 @@ class TradeExecutionService(LoggerMixin):
                 filtered_request["action"] = action_upper
                 filtered_request["side"] = action_upper.lower()
 
-        # Normalize quantity from amount or quantity fields
-        normalized_quantity: Optional[float] = None
+        # Only normalize explicit unit quantities, preserve USD sizing
         quantity_value = filtered_request.get("quantity")
         amount_value = filtered_request.get("amount")
         position_size_value = filtered_request.get("position_size_usd")
@@ -673,19 +672,26 @@ class TradeExecutionService(LoggerMixin):
                 errors.append(f"Invalid {field_name} value")
                 return None
 
-        normalized_quantity = _convert_to_float(quantity_value, "quantity")
-        if normalized_quantity is None:
-            normalized_quantity = _convert_to_float(amount_value, "amount")
-        if normalized_quantity is None and position_size_value is not None:
-            normalized_quantity = _convert_to_float(position_size_value, "position_size_usd")
+        # Only parse "quantity" field - don't convert amount/position_size_usd into quantity
+        if quantity_value is not None:
+            normalized_quantity = _convert_to_float(quantity_value, "quantity")
+            if normalized_quantity is None:
+                pass  # Error already added by _convert_to_float
+            elif normalized_quantity <= 0:
+                errors.append("Trade quantity must be greater than zero")
+            else:
+                filtered_request["quantity"] = normalized_quantity
 
-        if normalized_quantity is None:
-            errors.append("Trade quantity is required")
-        elif normalized_quantity <= 0:
-            errors.append("Trade quantity must be greater than zero")
-        else:
-            filtered_request["quantity"] = normalized_quantity
-            filtered_request.setdefault("amount", normalized_quantity)
+        # Keep amount and position_size_usd unchanged in filtered_request
+        # Don't set filtered_request["quantity"] from amount/position_size_usd
+
+        # Validate that at least one sizing method is provided
+        has_quantity = quantity_value is not None and "quantity" in filtered_request
+        has_amount = amount_value is not None
+        has_position_size = position_size_value is not None
+
+        if not (has_quantity or has_amount or has_position_size):
+            errors.append("Trade sizing is required (quantity, amount, or position_size_usd)")
 
         order_type = filtered_request.get("order_type", "MARKET")
         if isinstance(order_type, str):

--- a/app/services/trade_execution.py
+++ b/app/services/trade_execution.py
@@ -21,7 +21,6 @@ import uuid
 
 import aiohttp
 import structlog
-from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
 from app.core.database import AsyncSessionLocal, get_database
@@ -1181,7 +1180,7 @@ class TradeExecutionService(LoggerMixin):
         trade_request: Dict[str, Any],
         execution_result: Dict[str, Any],
         position_value_usd: float,
-        exchange_account_id: str = None,
+        exchange_account_id: Optional[str] = None,
         strategy_id: Optional[str] = None,
     ) -> None:
         """Record trade execution in database for audit trail."""

--- a/app/services/trading_strategies.py
+++ b/app/services/trading_strategies.py
@@ -4184,14 +4184,25 @@ class TradingStrategiesService(LoggerMixin):
             total_trades = safe_int(strategy_data.get("total_trades"), 0)
             net_pnl = safe_float(strategy_data.get("net_pnl"), 0.0)
 
-            total_return_dec = total_return / 100.0
-            benchmark_return_dec = benchmark_return / 100.0
+            returns_are_percent = abs(total_return) > 1.0 or abs(benchmark_return) > 1.0
+
+            total_return_dec = (total_return / 100.0) if returns_are_percent else total_return
+            benchmark_return_dec = (benchmark_return / 100.0) if returns_are_percent else benchmark_return
+
+            total_return_pct = total_return if returns_are_percent else total_return * 100
+            benchmark_return_pct = benchmark_return if returns_are_percent else benchmark_return * 100
 
             volatility_is_percent = abs(volatility) > 1.0
             volatility_dec = (volatility / 100.0) if volatility_is_percent else volatility
             max_drawdown_dec = (max_drawdown / 100.0) if abs(max_drawdown) > 1.0 else max_drawdown
 
-            annualized_return = total_return * (365 / period_days) if period_days else 0.0
+            annualization_factor = (365 / period_days) if period_days else 0.0
+            annualized_return_dec = total_return_dec * annualization_factor
+            benchmark_annualized_dec = benchmark_return_dec * annualization_factor
+
+            annualized_return = (
+                annualized_return_dec * 100 if returns_are_percent else annualized_return_dec
+            )
             volatility_annualized_dec = volatility_dec * (252 ** 0.5)
             volatility_annualized = (
                 volatility_annualized_dec * 100 if volatility_is_percent else volatility_annualized_dec
@@ -4199,7 +4210,7 @@ class TradingStrategiesService(LoggerMixin):
 
             # Core performance metrics
             perf_result["performance_metrics"] = {
-                "total_return_pct": total_return,
+                "total_return_pct": total_return_pct,
                 "annualized_return_pct": annualized_return,
                 "volatility_annualized": volatility_annualized,
                 "max_drawdown_pct": max_drawdown,
@@ -4221,30 +4232,31 @@ class TradingStrategiesService(LoggerMixin):
             calmar_ratio = 0.0
 
             if volatility_annualized_dec:
-                sharpe_ratio = (total_return_dec - risk_free_rate) / volatility_annualized_dec
+                sharpe_ratio = (annualized_return_dec - risk_free_rate) / volatility_annualized_dec
 
-            downside_vol_dec = volatility_dec * 0.7 * (252 ** 0.5)
-            if downside_vol_dec:
-                sortino_ratio = (total_return_dec - risk_free_rate) / downside_vol_dec
+            downside_vol_annualized_dec = volatility_dec * 0.7 * (252 ** 0.5)
+            if downside_vol_annualized_dec:
+                sortino_ratio = (annualized_return_dec - risk_free_rate) / downside_vol_annualized_dec
 
             if max_drawdown_dec:
-                calmar_ratio = total_return_dec / abs(max_drawdown_dec)
+                calmar_ratio = annualized_return_dec / abs(max_drawdown_dec)
 
             beta = safe_float(strategy_data.get("beta"), 0.8)
-            tracking_error_dec = volatility_dec * 0.5 if volatility_dec else 0.0
-            treynor_ratio = ((total_return_dec - risk_free_rate) / beta) if beta else 0.0
+            tracking_error_daily_dec = volatility_dec * 0.5 if volatility_dec else 0.0
+            tracking_error_annualized_dec = tracking_error_daily_dec * (252 ** 0.5)
+            treynor_ratio = ((annualized_return_dec - risk_free_rate) / beta) if beta else 0.0
             information_ratio = (
-                ((total_return_dec - benchmark_return_dec) / tracking_error_dec)
-                if tracking_error_dec else 0.0
+                ((annualized_return_dec - benchmark_annualized_dec) / tracking_error_annualized_dec)
+                if tracking_error_annualized_dec else 0.0
             )
-            jensen_alpha = total_return_dec - (
-                risk_free_rate + beta * (benchmark_return_dec - risk_free_rate)
+            jensen_alpha = annualized_return_dec - (
+                risk_free_rate + beta * (benchmark_annualized_dec - risk_free_rate)
             )
             var_adjusted_return = (
-                (total_return_dec / (volatility_dec * 1.65)) if volatility_dec else 0.0
+                (annualized_return_dec / (volatility_annualized_dec * 1.65)) if volatility_annualized_dec else 0.0
             )
             cvar_adjusted_return = (
-                (total_return_dec / (volatility_dec * 2.33)) if volatility_dec else 0.0
+                (annualized_return_dec / (volatility_annualized_dec * 2.33)) if volatility_annualized_dec else 0.0
             )
 
             perf_result["risk_adjusted_metrics"] = {
@@ -4260,12 +4272,12 @@ class TradingStrategiesService(LoggerMixin):
 
             # Benchmark comparison
             tracking_error = (
-                tracking_error_dec * 100 if volatility_is_percent else tracking_error_dec
+                tracking_error_annualized_dec * 100 if volatility_is_percent else tracking_error_annualized_dec
             )
             perf_result["benchmark_comparison"] = {
                 "benchmark": "BTC",
-                "outperformance": total_return - benchmark_return,
-                "outperformance_pct": ((total_return - benchmark_return) / abs(benchmark_return)) * 100 if benchmark_return else 0.0,
+                "outperformance": total_return_pct - benchmark_return_pct,
+                "outperformance_pct": ((total_return_pct - benchmark_return_pct) / abs(benchmark_return_pct)) * 100 if benchmark_return_pct else 0.0,
                 "beta": beta,
                 "correlation": strategy_data.get("correlation", 0.75),
                 "tracking_error": tracking_error,

--- a/app/services/trading_strategies.py
+++ b/app/services/trading_strategies.py
@@ -272,7 +272,7 @@ class DerivativesEngine(LoggerMixin):
         symbol: str,
         parameters: StrategyParameters,
         exchange: str = "binance",
-        user_id: str = None,
+        user_id: Optional[str] = None,
         strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute futures trading strategy."""
@@ -774,7 +774,7 @@ class SpotAlgorithms(LoggerMixin):
         self,
         symbol: str,
         parameters: StrategyParameters,
-        user_id: str = None,
+        user_id: Optional[str] = None,
         strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute momentum-based spot trading strategy."""
@@ -886,7 +886,7 @@ class SpotAlgorithms(LoggerMixin):
         self,
         symbol: str,
         parameters: StrategyParameters,
-        user_id: str = None,
+        user_id: Optional[str] = None,
         strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute mean reversion spot trading strategy."""
@@ -961,7 +961,7 @@ class SpotAlgorithms(LoggerMixin):
         self,
         symbol: str,
         parameters: StrategyParameters,
-        user_id: str = None,
+        user_id: Optional[str] = None,
         strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute breakout spot trading strategy."""
@@ -1429,12 +1429,12 @@ class TradingStrategiesService(LoggerMixin):
     async def execute_strategy(
         self,
         function: str,
-        strategy_type: str = None,
+        strategy_type: Optional[str] = None,
         symbol: str = "BTC/USDT",
         parameters: Dict[str, Any] = None,
         risk_mode: str = "balanced",
         exchange: str = "binance",
-        user_id: str = None,
+        user_id: Optional[str] = None,
         simulation_mode: bool = True
     ) -> Dict[str, Any]:
         """Main strategy execution router - handles all 25+ functions."""
@@ -5686,7 +5686,7 @@ class TradingStrategiesService(LoggerMixin):
             self.logger.error(f"Position fetch failed: {e}")
             return {"error": str(e)}
 
-    def _calculate_new_liquidation_price(self, position: Dict[str, Any], adjustment: float = 0, target_leverage: float = None) -> float:
+    def _calculate_new_liquidation_price(self, position: Dict[str, Any], adjustment: float = 0, target_leverage: Optional[float] = None) -> float:
         """Calculate new liquidation price after leverage adjustment."""
         try:
             # Extract values from position dict with validation
@@ -6646,7 +6646,7 @@ class TradingStrategiesService(LoggerMixin):
     async def options_chain(
         self,
         underlying_symbol: str,
-        expiry_date: str = None,
+        expiry_date: Optional[str] = None,
         user_id: str = None
     ) -> Dict[str, Any]:
         """Options chain analysis with real market data."""


### PR DESCRIPTION
## Summary
- ensure marketplace AI and community strategy entries propagate data quality badges instead of optimistic samples
- aggregate real trades and backtest data when building strategy performance metrics and return explicit "no data" structures when unavailable
- add data quality metadata to strategy performance responses so downstream consumers can show "Simulated / No live trades" indicators

## Testing
- pytest tests/api -k strategy --maxfail=1 *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68cc01c19e8c8322b197c8f829867b10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Strategy cards show data-quality labels and performance badges; community strategies surface live performance with provenance.
  - Trade requests include built-in validation with clear error messages.

- Improvements
  - Metrics standardized: total PnL replaces total return; win rate normalized (fraction/percent) across UI.
  - Explicit "No data" states replace optimistic defaults; neutral defaults for trades and supported symbols.
  - Portfolio loading made more resilient with timeouts, safe Redis fallbacks, and degraded-state recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->