### PR TITLE
Propagate platform strategy IDs through trade execution and metrics

### DIFF
--- a/app/services/trade_execution.py
+++ b/app/services/trade_execution.py
@@ -630,12 +630,22 @@ class TradeExecutionService(LoggerMixin):
         self,
         trade_request: Dict[str, Any],
         user_id: str,
-        simulation_mode: bool = True
+        simulation_mode: bool = True,
+        strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute trade with full lifecycle management."""
-        self.logger.info("💰 Executing trade", user_id=user_id, simulation=simulation_mode)
-        
+        self.logger.info(
+            "💰 Executing trade",
+            user_id=user_id,
+            simulation=simulation_mode,
+            strategy_id=strategy_id,
+        )
+
         try:
+            trade_request = dict(trade_request)
+            if strategy_id:
+                trade_request["strategy_id"] = strategy_id
+
             # Validate and resolve symbol
             symbol_validation = await self.symbol_validator.validate_and_resolve_symbol(
                 trade_request.get("symbol"),
@@ -679,9 +689,17 @@ class TradeExecutionService(LoggerMixin):
             
             # Execute based on mode
             if simulation_mode:
-                return await self._simulate_order_execution(trade_request, user_id)
+                return await self._simulate_order_execution(
+                    trade_request,
+                    user_id,
+                    strategy_id=strategy_id,
+                )
             else:
-                return await self._execute_real_order(trade_request, user_id)
+                return await self._execute_real_order(
+                    trade_request,
+                    user_id,
+                    strategy_id=strategy_id,
+                )
                 
         except Exception as e:
             self.logger.error("Trade execution failed", error=str(e), exc_info=True)
@@ -694,7 +712,8 @@ class TradeExecutionService(LoggerMixin):
     async def _simulate_order_execution(
         self,
         trade_request: Dict[str, Any],
-        user_id: str
+        user_id: str,
+        strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Simulate order execution using REAL market data and order books."""
         from app.services.real_market_data import real_market_data_service
@@ -751,7 +770,7 @@ class TradeExecutionService(LoggerMixin):
         executed_quantity = quantity * fill_rate
         fees = executed_quantity * execution_price * 0.001  # 0.1% trading fee
         
-        return {
+        response = {
             "success": True,
             "simulation_result": {
                 "order_id": f"SIM_{int(time.time())}_{uuid.uuid4().hex[:9]}",
@@ -764,11 +783,18 @@ class TradeExecutionService(LoggerMixin):
             },
             "timestamp": datetime.utcnow().isoformat()
         }
-    
+
+        if strategy_id:
+            response["strategy_id"] = strategy_id
+            response["simulation_result"]["strategy_id"] = strategy_id
+
+        return response
+
     async def _execute_real_order(
         self,
         trade_request: Dict[str, Any],
-        user_id: str
+        user_id: str,
+        strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Execute real order using user's exchange credentials."""
         try:
@@ -843,7 +869,8 @@ class TradeExecutionService(LoggerMixin):
                 trade_request=trade_request,
                 execution_result=execution_result,
                 position_value_usd=position_value_usd,
-                exchange_account_id=credentials.get("account_id")
+                exchange_account_id=credentials.get("account_id"),
+                strategy_id=strategy_id or trade_request.get("strategy_id"),
             )
             
             return {
@@ -1070,7 +1097,8 @@ class TradeExecutionService(LoggerMixin):
         trade_request: Dict[str, Any],
         execution_result: Dict[str, Any],
         position_value_usd: float,
-        exchange_account_id: str = None
+        exchange_account_id: str = None,
+        strategy_id: Optional[str] = None,
     ) -> None:
         """Record trade execution in database for audit trail."""
         try:
@@ -1078,25 +1106,37 @@ class TradeExecutionService(LoggerMixin):
                 from app.models.trading import Trade, TradeAction, TradeStatus, OrderType
                 from decimal import Decimal
                 import uuid
-                
+
                 # Validate required fields before creating Trade
                 if not exchange_account_id:
                     self.logger.error("Cannot create Trade record: exchange_account_id is required")
                     return
-                
+
                 # Convert IDs to proper UUID format (except external order IDs)
                 try:
                     user_uuid = uuid.UUID(user_id) if isinstance(user_id, str) else user_id
                 except ValueError as e:
                     self.logger.error("Invalid user_id UUID format", user_id=user_id, error=str(e))
                     return
-                
+
                 try:
                     account_uuid = uuid.UUID(exchange_account_id) if isinstance(exchange_account_id, str) else exchange_account_id
                 except ValueError as e:
                     self.logger.error("Invalid exchange_account_id UUID format", account_id=exchange_account_id, error=str(e))
                     return
-                
+
+                strategy_uuid = None
+                if strategy_id:
+                    try:
+                        strategy_uuid = uuid.UUID(str(strategy_id))
+                    except (ValueError, TypeError) as e:
+                        self.logger.warning(
+                            "Invalid strategy_id for trade record",
+                            strategy_id=strategy_id,
+                            error=str(e),
+                        )
+                        strategy_uuid = None
+
                 # Keep external order ID as string (don't convert to UUID)
                 external_order_id = execution_result.get("order_id")
                 
@@ -1133,12 +1173,14 @@ class TradeExecutionService(LoggerMixin):
                     market_price_at_execution=Decimal(str(execution_result["execution_price"])),
                     credits_used=0,  # Will be calculated by credit system
                     exchange_account_id=account_uuid,
+                    strategy_id=strategy_uuid,
                     executed_at=datetime.utcnow(),
                     completed_at=datetime.utcnow(),
                     meta_data={
                         "exchange": execution_result.get("exchange"),
                         "fills": execution_result.get("fills", []),
-                        "raw_response": execution_result.get("raw_response", {})
+                        "raw_response": execution_result.get("raw_response", {}),
+                        "strategy_id": str(strategy_uuid) if strategy_uuid else trade_request.get("strategy_id"),
                     }
                 )
                 
@@ -1167,7 +1209,8 @@ class TradeExecutionService(LoggerMixin):
         quantity: float,
         order_type: str = "market",
         exchange: str = "auto",
-        user_id: str = "system"
+        user_id: str = "system",
+        strategy_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Execute real trade for autonomous operations.
@@ -1183,11 +1226,18 @@ class TradeExecutionService(LoggerMixin):
                 "quantity": quantity,
                 "order_type": order_type.upper(),
                 "exchange": exchange,
-                "user_id": user_id
+                "user_id": user_id,
             }
-            
+
+            if strategy_id:
+                trade_request["strategy_id"] = strategy_id
+
             # Execute using existing real order execution (now with user credentials)
-            result = await self._execute_real_order(trade_request, user_id)
+            result = await self._execute_real_order(
+                trade_request,
+                user_id,
+                strategy_id=strategy_id,
+            )
             
             if result.get("success"):
                 execution_data = result.get("execution_result", {})


### PR DESCRIPTION
## Summary
- propagate seeded platform strategy UUIDs through spot strategy execution so downstream services can identify the originating AI function
- extend TradeExecutionService to accept optional strategy identifiers in both simulation and live paths and persist them on recorded Trade rows
- enhance the real performance tracker and strategy marketplace integration to resolve platform UUIDs, optionally include simulation activity, and flag data quality for metrics consumers

## Testing
- pytest tests/test_trade_execution_comprehensive.py -k performance *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc01ca15b88322be142aa30038c7a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Performance analytics can optionally include simulated trades; metrics now show data quality and trade counts.
  - Trades are now associated with strategies in both simulation and live modes, reflected in records and analytics.
  - Introduces a platform strategy framework with a seeded catalog and automatic ID mapping for end-to-end routing.
  - Marketplace fetches performance by platform strategy when available, with graceful fallbacks.

- Refactor
  - Improved input validation, UUID normalization, and clearer logging.
  - Performance history storage now records source and live/simulation flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->