### PR TITLE
Fix chatbot visibility by moving ChatWidget to global DashboardLayout

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -306,6 +306,9 @@ const DashboardLayout: React.FC = () => {
           </div>
         </main>
       </div>
+
+      {/* Global Chat Widget - Available on all pages */}
+      <ChatWidget />
     </div>
   );
 };
@@ -447,8 +450,6 @@ const SidebarContent: React.FC<SidebarContentProps> = ({
         </div>
       </nav>
 
-      {/* Chat Widget - Available on all pages */}
-      <ChatWidget />
     </div>
   );
 };


### PR DESCRIPTION
- Move ChatWidget from SidebarContent to main DashboardLayout component
- Ensures chatbot is visible on all dashboard pages consistently
- Removes duplicate ChatWidget instance from sidebar
- Maintains fixed position in bottom-right corner across all pages

🤖 Generated with [Claude Code](https://claude.ai/code)