### PR TITLE
Ensure strategy id in real order simulation fallback

### DIFF
--- a/app/services/trade_execution.py
+++ b/app/services/trade_execution.py
@@ -813,8 +813,12 @@ class TradeExecutionService(LoggerMixin):
                     symbol=trade_request['symbol']
                 )
 
-                # Execute as simulation instead
-                simulation_result = await self._execute_simulated_order(trade_request, user_id)
+                # Execute as simulation instead using standard simulation path
+                simulation_result = await self._simulate_order_execution(
+                    trade_request,
+                    user_id,
+                    strategy_id=strategy_id,
+                )
 
                 # Add a notice that this was executed in simulation mode
                 if simulation_result.get("success"):


### PR DESCRIPTION
## Summary
- route the real-order credential fallback through the standard simulation execution path
- ensure the simulation fallback includes any provided strategy identifier in the response payload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccd6faa81083229bd0037c18a1fb95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simulated trade confirmations now include the associated strategy ID (when available), improving traceability across trade history and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->