### PR TITLE
Ensure trade execution requests include explicit side

### DIFF
--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -1328,9 +1328,11 @@ Provide a helpful response using the real data available. Never use placeholder 
         if symbol:
             trade_request["symbol"] = symbol
 
-        action = trade_params.get("action")
+        action = trade_params.get("action") or trade_params.get("side")
         if action:
-            trade_request["action"] = action.upper() if isinstance(action, str) else action
+            normalized_action = action.upper() if isinstance(action, str) else action
+            trade_request["action"] = normalized_action
+            trade_request["side"] = normalized_action
 
         order_type = trade_params.get("order_type")
         if isinstance(order_type, str):

--- a/tests/api/test_unified_chat_trade_execution.py
+++ b/tests/api/test_unified_chat_trade_execution.py
@@ -92,6 +92,9 @@ async def test_live_trade_uses_simulation_true(unified_service: UnifiedChatServi
 
     unified_service.trade_executor.execute_trade.assert_awaited_once()
     exec_args = unified_service.trade_executor.execute_trade.call_args.args
+    request_payload = exec_args[0]
+    assert request_payload["action"] == "SELL"
+    assert request_payload["side"] == "SELL"
     assert exec_args[2] is True
 
 


### PR DESCRIPTION
## Summary
- ensure unified chat trade requests mirror the action into both action and side for executor compatibility
- add a regression test covering the sell path to assert the side flag is forwarded to the trade executor

## Testing
- pytest tests/api/test_unified_chat_trade_execution.py


------
https://chatgpt.com/codex/tasks/task_e_68cd5fd341a08322a7027ba498f343da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trade execution requests now consistently include both Action and Side fields with normalized (uppercase) values, improving reliability and validation during order processing.

* **Tests**
  * Enhanced simulation-mode test to assert the payload includes matching Action and Side values and verifies the simulation flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->