### PR TITLE
Add paper trading stats and reset support

### DIFF
--- a/frontend/src/constants/trading.ts
+++ b/frontend/src/constants/trading.ts
@@ -308,8 +308,11 @@ export const API_ENDPOINTS = {
   TRADE_POSITIONS: '/trading/positions',
   
   // Paper Trading Endpoints
+  PAPER_TRADING_SETUP: '/paper-trading/setup',
+  PAPER_TRADING_PERFORMANCE: '/paper-trading/performance',
   PAPER_TRADING_EXECUTE: '/paper-trading/execute',
   PAPER_TRADING_STATS: '/paper-trading/stats',
+  PAPER_TRADING_RESET: '/paper-trading/reset',
   PAPER_TRADING_HISTORY: '/paper-trading/history',
   
   // User Endpoints

--- a/frontend/src/lib/api/tradingApi.ts
+++ b/frontend/src/lib/api/tradingApi.ts
@@ -24,16 +24,19 @@ import { mapTradeExecutionResponse } from '@/lib/utils/typeMappers';
 export const paperTradingApi = {
   async getStats(): Promise<PaperTradingStats> {
     try {
-      const response = await apiClient.get<ApiResponse<PaperTradingStats>>(
-        API_ENDPOINTS.PAPER_TRADING_STATS
-      );
-      return response.data.data || {
-        totalTrades: 0,
-        winRate: 0,
-        totalProfit: 0,
-        bestTrade: 0,
-        worstTrade: 0,
-        readyForLive: false
+      const response = await apiClient.get(API_ENDPOINTS.PAPER_TRADING_STATS);
+      const statsPayload = response.data || {};
+      const portfolio = statsPayload.virtual_portfolio || {};
+      const stats = statsPayload.stats || {};
+      const performance = portfolio.performance_metrics || {};
+
+      return {
+        totalTrades: stats.total_trades ?? performance.total_trades ?? 0,
+        winRate: stats.win_rate ?? performance.win_rate ?? 0,
+        totalProfit: stats.total_profit ?? performance.total_profit_loss ?? 0,
+        bestTrade: stats.best_trade ?? performance.best_trade ?? 0,
+        worstTrade: stats.worst_trade ?? performance.worst_trade ?? 0,
+        readyForLive: statsPayload.ready_for_live_trading ?? false
       };
     } catch (error) {
       console.error('Failed to fetch paper trading stats:', error);

--- a/frontend/src/store/globalPaperModeStore.ts
+++ b/frontend/src/store/globalPaperModeStore.ts
@@ -36,18 +36,21 @@ export const useGlobalPaperModeStore = create<GlobalPaperModeState>()(
 
       setGlobalPaperMode: async (enabled: boolean) => {
         set({ isLoading: true });
-        
+
         try {
           if (enabled) {
             // Initialize paper trading
             const response = await apiClient.post('/paper-trading/setup');
-            
+
             if (response.data.success) {
-              set({ 
+              const portfolio =
+                response.data.virtual_portfolio || response.data.paper_portfolio || response.data.portfolio || {};
+
+              set({
                 isPaperMode: true,
-                paperBalance: response.data.data.balance || 10000
+                paperBalance: portfolio.cash_balance ?? portfolio.balance ?? 10000
               });
-              
+
               // Fetch initial stats
               await get().fetchPaperStats();
             }
@@ -77,11 +80,22 @@ export const useGlobalPaperModeStore = create<GlobalPaperModeState>()(
       fetchPaperStats: async () => {
         try {
           const response = await apiClient.get('/paper-trading/stats');
-          
+
           if (response.data.success) {
-            set({ 
-              paperStats: response.data.data,
-              paperBalance: response.data.data.currentBalance || get().paperBalance
+            const portfolio = response.data.virtual_portfolio || response.data.paper_portfolio || {};
+            const stats = response.data.stats || {};
+            const performance = portfolio.performance_metrics || {};
+
+            set({
+              paperStats: {
+                totalTrades: stats.total_trades ?? performance.total_trades ?? 0,
+                winRate: stats.win_rate ?? performance.win_rate ?? 0,
+                totalProfit: stats.total_profit ?? performance.total_profit_loss ?? 0,
+                bestTrade: stats.best_trade ?? performance.best_trade ?? 0,
+                worstTrade: stats.worst_trade ?? performance.worst_trade ?? 0,
+                readyForLive: response.data.ready_for_live_trading ?? false
+              },
+              paperBalance: portfolio.cash_balance ?? get().paperBalance
             });
           }
         } catch (error) {
@@ -91,16 +105,18 @@ export const useGlobalPaperModeStore = create<GlobalPaperModeState>()(
 
       resetPaperAccount: async () => {
         set({ isLoading: true });
-        
+
         try {
           const response = await apiClient.post('/paper-trading/reset');
-          
+
           if (response.data.success) {
+            const portfolio = response.data.virtual_portfolio || {};
+
             set({
-              paperBalance: 10000,
+              paperBalance: portfolio.cash_balance ?? 10000,
               paperStats: null
             });
-            
+
             await get().fetchPaperStats();
           }
         } catch (error) {


### PR DESCRIPTION
## Summary
- add REST endpoints for paper trading stats and reset while tolerating existing account setup responses
- implement engine-level reset logic and expose paper trading API constants for the frontend
- normalize paper mode stores and trading API adapters to consume the new payload format

## Testing
- pytest test_paper_trading_setup.py *(fails: requires running API server for auth/login)*

------
https://chatgpt.com/codex/tasks/task_e_68cd607152e08322bacbfb8c9b0499f4