### PR TITLE
HOTFIX: Fix critical IndentationError causing production boot failure

### DIFF
--- a/app/services/unified_strategy_service.py
+++ b/app/services/unified_strategy_service.py
@@ -823,11 +823,11 @@ class UnifiedStrategyService(LoggerMixin):
                     is_active=True
                 )
 
-                db.add(new_access)
-                await db.commit()
-                await db.refresh(new_access)
+            db.add(new_access)
+            await db.commit()
+            await db.refresh(new_access)
 
-                self.logger.info(
+            self.logger.info(
                     "Granted new strategy access",
                     user_id=user_id,
                     strategy_id=strategy_id,
@@ -835,9 +835,9 @@ class UnifiedStrategyService(LoggerMixin):
                     access_id=str(new_access.id)
                 )
 
-                return new_access
+            return new_access
 
-            except IntegrityError:
+        except IntegrityError:
                 # Concurrent insert detected - rollback and update existing record
                 await db.rollback()
 


### PR DESCRIPTION
- Fix IndentationError at line 826 in unified_strategy_service.py
- Correct indentation for db.add(), db.commit(), db.refresh() calls
- Align try-except blocks with proper Python indentation standards
- Resolve production server boot failure (gunicorn Worker failed to boot)
- Ensure consistent 12-space indentation in database transaction blocks
- Fix 6 indentation issues preventing module import

Critical production fix - server was failing to start due to syntax errors.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up indentation and alignment within strategy access handling for consistent formatting. No changes to functionality, performance, or user-facing behavior.

* **Refactor**
  * Re-indented try/except block to improve readability and maintainability. Logging and success paths remain unchanged, with no impact on workflows or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->