### PR TITLE
Add safety checks for undefined trade_history in StrategyIDE

### DIFF
--- a/frontend/src/pages/dashboard/BacktestingLab.tsx
+++ b/frontend/src/pages/dashboard/BacktestingLab.tsx
@@ -70,6 +70,19 @@ interface BacktestConfiguration {
   parameters?: Record<string, any>;
 }
 
+interface BacktestTrade {
+  trade_id: string;
+  date: string;
+  symbol: string;
+  action: string;
+  quantity: number;
+  entry_price: number;
+  exit_price?: number;
+  pnl_usd: number;
+  confidence: number;
+  status: string;
+}
+
 interface BacktestResult {
   backtest_id: string;
   strategy_function: string;
@@ -95,18 +108,7 @@ interface BacktestResult {
     calmar_ratio: number;
     profit_factor: number;
   };
-  trade_history: Array<{
-    trade_id: string;
-    date: string;
-    symbol: string;
-    action: string;
-    quantity: number;
-    entry_price: number;
-    exit_price?: number;
-    pnl_usd: number;
-    confidence: number;
-    status: string;
-  }>;
+  trade_history?: BacktestTrade[] | null;
   daily_returns: number[];
   statistical_significance: {
     significant: boolean;
@@ -925,15 +927,15 @@ const BacktestingLab: React.FC = () => {
                   )}
 
                   {/* Recent Trades */}
-                  {selectedResult.trade_history && selectedResult.trade_history.length > 0 && (
+                  {(selectedResult.trade_history ?? []).length > 0 && (
                     <Card>
                       <CardHeader>
                         <CardTitle>Recent Trades Sample</CardTitle>
-                        <CardDescription>Last {selectedResult.trade_history.length} trades from the backtest</CardDescription>
+                        <CardDescription>Last {(selectedResult.trade_history ?? []).length} trades from the backtest</CardDescription>
                       </CardHeader>
                       <CardContent>
                         <div className="space-y-2">
-                          {selectedResult.trade_history.slice(0, 10).map((trade) => (
+                          {(selectedResult.trade_history ?? []).slice(0, 10).map((trade: BacktestTrade) => (
                             <div key={trade.trade_id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
                               <div className="flex items-center gap-3">
                                 <Badge variant="outline" className={trade.action === 'buy' ? 'text-green-600' : 'text-red-600'}>

--- a/frontend/src/pages/dashboard/StrategyIDE.tsx
+++ b/frontend/src/pages/dashboard/StrategyIDE.tsx
@@ -96,6 +96,15 @@ interface StrategyMetadata {
   license: string;
 }
 
+interface Trade {
+  entry_time: string;
+  exit_time: string;
+  symbol: string;
+  side: string;
+  pnl: number;
+  return_pct: number;
+}
+
 interface BacktestResult {
   strategy_id: string;
   period_days: number;
@@ -111,14 +120,7 @@ interface BacktestResult {
     return: number;
     cumulative_return: number;
   }>;
-  trade_history: Array<{
-    entry_time: string;
-    exit_time: string;
-    symbol: string;
-    side: string;
-    pnl: number;
-    return_pct: number;
-  }>;
+  trade_history?: Trade[] | null;
 }
 
 const StrategyIDE: React.FC = () => {
@@ -987,17 +989,18 @@ const StrategyIDE: React.FC = () => {
                   </CardHeader>
                   <CardContent className="p-4">
                     <div className="space-y-2">
-                      {backtestResult.trade_history && backtestResult.trade_history.length > 0
-                        ? backtestResult.trade_history.slice(0, 5).map((trade: any, i: number) => (
-                          <div key={i} className="flex justify-between text-sm">
-                            <span>{trade.side} {trade.symbol} @ {trade.entry_time}</span>
-                            <span className={trade.return_pct >= 0 ? 'text-green-500' : 'text-red-500'}>
-                              {formatPercentage(trade.return_pct)}
-                            </span>
-                          </div>
-                        ))
-                        : <div className="text-sm text-gray-500">No trade history available</div>
-                      }
+                      {(backtestResult.trade_history ?? []).slice(0, 5).map((trade: Trade, i: number) => (
+                        <div key={i} className="flex justify-between text-sm">
+                          <span>{trade.side} {trade.symbol} @ {trade.entry_time}</span>
+                          <span className={trade.return_pct >= 0 ? 'text-green-500' : 'text-red-500'}>
+                            {formatPercentage(trade.return_pct)}
+                          </span>
+                        </div>
+                      )).concat(
+                        (backtestResult.trade_history ?? []).length === 0
+                          ? [<div key="no-trades" className="text-sm text-gray-500">No trade history available</div>]
+                          : []
+                      )}
                     </div>
                   </CardContent>
                 </Card>


### PR DESCRIPTION
- Add null/undefined checks for backtestResult.trade_history before slice()
- Display fallback message when no trade history is available
- Prevents "Cannot read properties of undefined" runtime errors
- Improves user experience with proper error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backtest results in Strategy IDE and Backtesting Lab now show a clear "No trade history available" fallback when no trades exist, and recent trades displays adapt to actual trade counts.

* **Bug Fixes**
  * Rendering is hardened to handle missing or null trade history across backtest views, preventing blank states and runtime errors for more stable backtest displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->