### PR TITLE
Fix Save Draft 422 validation error in Strategy IDE

### DIFF
--- a/frontend/src/pages/dashboard/StrategyIDE.tsx
+++ b/frontend/src/pages/dashboard/StrategyIDE.tsx
@@ -96,6 +96,15 @@ interface StrategyMetadata {
   license: string;
 }
 
+interface Trade {
+  entry_time: string;
+  exit_time: string;
+  symbol: string;
+  side: string;
+  pnl: number;
+  return_pct: number;
+}
+
 interface BacktestResult {
   strategy_id: string;
   period_days: number;
@@ -111,14 +120,7 @@ interface BacktestResult {
     return: number;
     cumulative_return: number;
   }>;
-  trade_history: Array<{
-    entry_time: string;
-    exit_time: string;
-    symbol: string;
-    side: string;
-    pnl: number;
-    return_pct: number;
-  }>;
+  trade_history?: Trade[] | null;
 }
 
 const StrategyIDE: React.FC = () => {
@@ -987,14 +989,18 @@ const StrategyIDE: React.FC = () => {
                   </CardHeader>
                   <CardContent className="p-4">
                     <div className="space-y-2">
-                      {backtestResult.trade_history.slice(0, 5).map((trade, i) => (
+                      {(backtestResult.trade_history ?? []).slice(0, 5).map((trade: Trade, i: number) => (
                         <div key={i} className="flex justify-between text-sm">
-                          <span>{trade.symbol}</span>
-                          <span className={trade.pnl >= 0 ? 'text-green-500' : 'text-red-500'}>
+                          <span>{trade.side} {trade.symbol} @ {trade.entry_time}</span>
+                          <span className={trade.return_pct >= 0 ? 'text-green-500' : 'text-red-500'}>
                             {formatPercentage(trade.return_pct)}
                           </span>
                         </div>
-                      ))}
+                      )).concat(
+                        (backtestResult.trade_history ?? []).length === 0
+                          ? [<div key="no-trades" className="text-sm text-gray-500">No trade history available</div>]
+                          : []
+                      )}
                     </div>
                   </CardContent>
                 </Card>

--- a/frontend/src/pages/dashboard/StrategyIDE.tsx
+++ b/frontend/src/pages/dashboard/StrategyIDE.tsx
@@ -94,6 +94,11 @@ interface StrategyMetadata {
   tags: string[];
   is_public: boolean;
   license: string;
+  // Optional fields for backend compatibility
+  parameters?: Record<string, any>;
+  risk_parameters?: Record<string, any>;
+  entry_conditions?: Array<Record<string, any>>;
+  exit_conditions?: Array<Record<string, any>>;
 }
 
 interface Trade {
@@ -184,8 +189,13 @@ const StrategyIDE: React.FC = () => {
   const saveStrategyMutation = useMutation({
     mutationFn: async (data: { code: string; metadata: StrategyMetadata; is_draft: boolean }) => {
       const response = await apiClient.post('/strategies/save', {
+        name: (data.metadata.name || 'Untitled Strategy').trim(),
+        description: (data.metadata.description || `Generated on ${new Date().toISOString()}`).trim(),
         code: data.code,
-        metadata: data.metadata,
+        parameters: data.metadata.parameters || {},
+        risk_parameters: data.metadata.risk_parameters || null,
+        entry_conditions: data.metadata.entry_conditions || null,
+        exit_conditions: data.metadata.exit_conditions || null,
         is_draft: data.is_draft
       });
       return response.data;


### PR DESCRIPTION
- Fixed frontend API request structure to include required 'name' field
- Updated StrategyIDE.tsx to send proper data format matching backend StrategySaveRequest model
- Resolved 422 Unprocessable Entity error when saving strategy drafts

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saving a strategy now captures more details as top-level fields: explicit name (auto “Untitled Strategy”), description (auto timestamp), parameters, risk settings, and entry/exit conditions; fields are optional and auto-filled when absent.
* **Bug Fixes / UX**
  * Backtest view handles missing trade history gracefully, shows "No trade history available" when empty, displays trades as "side symbol @ entry_time" and colors returns green/red.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->