### PR TITLE
Stop fallback metrics from injecting mock data

### DIFF
--- a/app/services/market_analysis_core.py
+++ b/app/services/market_analysis_core.py
@@ -259,27 +259,42 @@ class MarketAnalysisService(LoggerMixin):
             ]
             
             analysis_results = {}
-            
+
             for symbol in symbol_list:
                 analysis = await self._analyze_symbol_technical(symbol, timeframe, indicator_list)
                 analysis_results[symbol] = analysis
-            
+
+            available_symbols = [
+                symbol for symbol, analysis in analysis_results.items()
+                if analysis.get("data_quality") != "no_data"
+            ]
+            unavailable_symbols = [
+                symbol for symbol in symbol_list if symbol not in available_symbols
+            ]
+
             response_time = time.time() - start_time
-            await self._update_performance_metrics(response_time, True, user_id)
-            
-            return {
-                "success": True,
-                "function": "technical_analysis", 
-                "data": analysis_results,
-                "metadata": {
-                    "symbols_analyzed": len(symbol_list),
-                    "timeframe": timeframe,
-                    "indicators_used": indicator_list,
-                    "response_time_ms": round(response_time * 1000, 2),
-                    "timestamp": datetime.utcnow().isoformat()
-                }
+            overall_success = bool(available_symbols)
+            await self._update_performance_metrics(response_time, overall_success, user_id)
+
+            metadata = {
+                "symbols_analyzed": len(symbol_list),
+                "timeframe": timeframe,
+                "indicators_used": indicator_list,
+                "response_time_ms": round(response_time * 1000, 2),
+                "timestamp": datetime.utcnow().isoformat(),
+                "symbols_with_data": len(available_symbols),
+                "symbols_without_data": len(unavailable_symbols),
             }
-            
+            if unavailable_symbols:
+                metadata["unavailable_symbols"] = unavailable_symbols
+
+            return {
+                "success": overall_success,
+                "function": "technical_analysis",
+                "data": analysis_results,
+                "metadata": metadata,
+            }
+
         except Exception as e:
             await self._update_performance_metrics(time.time() - start_time, False, user_id)
             raise e
@@ -733,7 +748,8 @@ class MarketAnalysisService(LoggerMixin):
                 "confidence": self._calculate_analysis_confidence(technical_analysis, len(price_data)),
                 "timestamp": datetime.utcnow().isoformat(),
                 "data_source": "real_market_data",
-                "data_points": len(price_data)
+                "data_points": len(price_data),
+                "data_quality": "real_market_data",
             }
             
         except Exception as e:
@@ -758,97 +774,12 @@ class MarketAnalysisService(LoggerMixin):
                 self.logger.info(f"✅ Fetched {len(ohlcv_data)} real candles for {symbol}")
                 return ohlcv_data
 
-            # Fallback to fetching current price if no historical data
-            current_price_data = await real_market_data_service.get_real_price(symbol)
-            if not current_price_data or current_price_data.get('price', 0) <= 0:
-                return []
-            
-            # Only use synthetic data as last resort fallback
-            self.logger.warning(f"⚠️ Using synthetic fallback for {symbol}")
-            current_price = current_price_data['price']
-            price_data = []
-            base_price = current_price
-            
-            # Market parameters based on crypto volatility
-            volatility = 0.03  # 3% daily volatility (realistic for crypto)
-            trend_bias = 0.0   # Start neutral
-            
-            # Determine market cycle for this symbol
-            # Use symbol hash to create deterministic but varied patterns
-            symbol_hash = hash(symbol) % 100
-            
-            if symbol_hash < 20:  # 20% bullish trend
-                trend_bias = 0.001  # 0.1% upward bias per period
-                volatility = 0.025  # Lower volatility in trends
-            elif symbol_hash < 40:  # 20% bearish trend
-                trend_bias = -0.001  # 0.1% downward bias
-                volatility = 0.025
-            elif symbol_hash < 60:  # 20% high volatility
-                volatility = 0.05   # 5% volatility
-                trend_bias = 0.0
-            elif symbol_hash < 80:  # 20% accumulation phase
-                volatility = 0.015  # Low volatility
-                trend_bias = 0.0
-            else:  # 20% breakout pattern
-                volatility = 0.02
-                trend_bias = 0.0
-            
-            # Generate price history with momentum
-            momentum = 0  # Track short-term momentum
-            
-            for i in range(periods):
-                # Add momentum factor (creates more realistic trends)
-                momentum = momentum * 0.9  # Decay factor
-                
-                # Breakout pattern for last group
-                if symbol_hash >= 80 and i > periods * 0.7:
-                    # Breakout in last 30% of data
-                    trend_bias = 0.002  # Strong upward movement
-                    volatility = 0.04   # Increased volatility
-                
-                # Calculate price change with trend and momentum
-                random_component = np.random.normal(0, volatility)
-                price_change = trend_bias + momentum * 0.1 + random_component
-                
-                # Add momentum based on recent movement
-                if i > 0 and price_change > 0.02:
-                    momentum = min(0.5, momentum + 0.1)  # Bullish momentum
-                elif i > 0 and price_change < -0.02:
-                    momentum = max(-0.5, momentum - 0.1)  # Bearish momentum
-                
-                # Calculate new price
-                price = base_price * (1 + price_change)
-                
-                # Ensure price stays positive
-                price = max(price, base_price * 0.5)  # Don't drop below 50% of start
-                
-                # Generate realistic volume patterns
-                # Higher volume on larger price movements
-                base_volume = 5000000  # 5M base volume
-                volume_multiplier = 1 + abs(price_change) * 10  # More volume on big moves
-                volume = base_volume * volume_multiplier * np.random.uniform(0.8, 1.2)
-                
-                # Generate high/low with realistic wicks
-                wick_size = abs(price_change) + volatility * 0.5
-                high = price * (1 + wick_size)
-                low = price * (1 - wick_size)
-                
-                # Ensure open is between high and low
-                open_price = base_price if i == 0 else price_data[-1]['close']
-                
-                price_data.append({
-                    'timestamp': (datetime.utcnow() - timedelta(hours=periods-i)).isoformat(),
-                    'open': float(open_price),
-                    'high': float(high),
-                    'low': float(low),
-                    'close': float(price),
-                    'volume': float(volume)
-                })
-                
-                base_price = price
-            
-            # Reverse to get chronological order
-            return list(reversed(price_data))
+            self.logger.warning(
+                "No historical OHLCV data available from real market data service",
+                symbol=symbol,
+                timeframe=timeframe,
+            )
+            return []
             
         except Exception as e:
             logger.error("Failed to get historical price data", symbol=symbol, error=str(e))
@@ -1038,58 +969,18 @@ class MarketAnalysisService(LoggerMixin):
     
     async def _fallback_technical_analysis(self, symbol: str, timeframe: str) -> Dict[str, Any]:
         """Fallback technical analysis when real data is unavailable."""
-        try:
-            # Try to get at least current price
-            current_data = await market_data_feeds.get_real_time_price(symbol)
-            current_price = float(current_data.get("price", 50000)) if current_data.get("success") else 50000.0
-            
-            return {
-                "symbol": symbol,
-                "timeframe": timeframe,
-                "analysis": {
-                    "trend": {
-                        "direction": "NEUTRAL",
-                        "strength": 5.0,
-                        "sma_20": current_price,
-                        "sma_50": current_price,
-                        "ema_12": current_price,
-                        "ema_26": current_price
-                    },
-                    "momentum": {
-                        "rsi": 50.0,
-                        "macd": {
-                            "macd": 0.0,
-                            "signal": 0.0,
-                            "histogram": 0.0,
-                            "trend": "NEUTRAL"
-                        }
-                    },
-                    "price": {
-                        "current": round(current_price, 2),
-                        "high_24h": round(current_price * 1.02, 2),
-                        "low_24h": round(current_price * 0.98, 2),
-                        "volume": 1000000
-                    }
-                },
-                "signals": {"buy": 1, "sell": 1, "neutral": 1},
-                "confidence": 3.0,
-                "timestamp": datetime.utcnow().isoformat(),
-                "data_source": "fallback_with_current_price"
-            }
-        except Exception:
-            return {
-                "symbol": symbol,
-                "timeframe": timeframe,
-                "analysis": {
-                    "trend": {"direction": "NEUTRAL", "strength": 5.0, "sma_20": 50000, "sma_50": 50000, "ema_12": 50000, "ema_26": 50000},
-                    "momentum": {"rsi": 50.0, "macd": {"macd": 0.0, "signal": 0.0, "histogram": 0.0, "trend": "NEUTRAL"}},
-                    "price": {"current": 50000, "high_24h": 51000, "low_24h": 49000, "volume": 1000000}
-                },
-                "signals": {"buy": 1, "sell": 1, "neutral": 1},
-                "confidence": 1.0,
-                "timestamp": datetime.utcnow().isoformat(),
-                "data_source": "emergency_fallback"
-            }
+        timestamp = datetime.utcnow().isoformat()
+        return {
+            "symbol": symbol,
+            "timeframe": timeframe,
+            "analysis": {},
+            "signals": {},
+            "confidence": 0.0,
+            "timestamp": timestamp,
+            "data_source": "no_market_data",
+            "data_quality": "no_data",
+            "error": "historical_price_data_unavailable"
+        }
     
     async def _analyze_price_action_sentiment(self, symbol: str, timeframes: List[str]) -> Dict[str, Any]:
         """Analyze sentiment based on REAL price action."""

--- a/app/services/market_analysis_core.py
+++ b/app/services/market_analysis_core.py
@@ -291,6 +291,7 @@ class MarketAnalysisService(LoggerMixin):
             return {
                 "success": overall_success,
                 "function": "technical_analysis",
+                "technical_analysis": analysis_results,
                 "data": analysis_results,
                 "metadata": metadata,
             }

--- a/app/services/trading_strategies.py
+++ b/app/services/trading_strategies.py
@@ -4785,50 +4785,18 @@ class TradingStrategiesService(LoggerMixin):
 
             # No data available
             return {
-                "total_return": 15.5,
-                "benchmark_return": 12.0,
-                "volatility": 0.045,
-                "max_drawdown": -8.5,
-                "recovery_time": 12,
-                "win_rate": 62,
-                "profit_factor": 1.75,
-                "avg_trade": 2.3,
-                "largest_win": 8.5,
-                "largest_loss": -4.2,
-                "returns_are_percent": True,
-                "benchmark_is_percent": True,
-                "volatility_is_percent": False,
-                "max_drawdown_is_percent": True,
-                "win_rate_is_percent": True,
-                "average_trade_is_percent": True,
-                "largest_win_is_percent": True,
-                "largest_loss_is_percent": True
+                "data_quality": "no_data",
+                "status": "no_data_available",
+                "message": "No verified trades or backtests found for requested period",
+                "total_trades": 0,
             }
         except Exception as e:
             self.logger.error("Failed to get strategy performance data", error=str(e))
-            # Return default data to prevent complete failure
             return {
-                "total_return": 0.0,
-                "benchmark_return": 0.0,
-                        "benchmark_return_units": "decimal",
-                "volatility": 0.0,
-                "max_drawdown": 0.0,
-                "recovery_time": None,
-                "win_rate": 0.0,
-                "profit_factor": 0.0,
-                "avg_trade": 0.0,
-                "largest_win": 0.0,
-                        "largest_win_units": "decimal",
-                "largest_loss": 0.0,
-                        "largest_loss_units": "decimal",
-                "returns_are_percent": True,
-                "benchmark_is_percent": True,
-                "volatility_is_percent": False,
-                "max_drawdown_is_percent": True,
-                "win_rate_is_percent": True,
-                "average_trade_is_percent": True,
-                "largest_win_is_percent": True,
-                "largest_loss_is_percent": True
+                "data_quality": "error",
+                "status": "error",
+                "error": str(e),
+                "total_trades": 0,
             }
 
     @staticmethod
@@ -4943,22 +4911,47 @@ class TradingStrategiesService(LoggerMixin):
             strategy_data = await self._get_strategy_performance_data(strategy_name, analysis_period, user_id)
             normalized_data, unit_flags = self._normalize_strategy_performance_data(strategy_data)
 
-            def _safe_float(value: Any, default: float) -> float:
+            def _safe_float(value: Any) -> Optional[float]:
                 try:
                     if value is None:
-                        return default
+                        return None
                     return float(value)
                 except (TypeError, ValueError):
-                    return default
+                    return None
 
-            total_return = _safe_float(normalized_data.get("total_return"), 0.155)
-            benchmark_return = _safe_float(normalized_data.get("benchmark_return"), 0.12)
-            volatility = _safe_float(normalized_data.get("volatility"), 0.045)
-            max_drawdown = _safe_float(normalized_data.get("max_drawdown"), -0.085)
-            win_rate = _safe_float(normalized_data.get("win_rate"), 0.62)
-            average_trade = _safe_float(normalized_data.get("avg_trade"), 0.023)
-            largest_win = _safe_float(normalized_data.get("largest_win"), 0.085)
-            largest_loss = _safe_float(normalized_data.get("largest_loss"), -0.042)
+            data_quality = strategy_data.get("data_quality", "unknown")
+            perf_result["data_quality"] = data_quality
+            perf_result["status"] = strategy_data.get("status", data_quality)
+            perf_result["raw_performance"] = strategy_data
+            perf_result["unit_metadata"] = unit_flags
+
+            if data_quality in {"no_data", "error"} or not normalized_data:
+                perf_result["performance_metrics"] = {}
+                perf_result["risk_adjusted_metrics"] = {}
+                perf_result["benchmark_comparison"] = {}
+                perf_result["attribution_analysis"] = {}
+                perf_result["optimization_recommendations"] = []
+                perf_result["error"] = strategy_data.get("error") or strategy_data.get("message") or "No verified performance data available"
+                return perf_result
+
+            total_return = _safe_float(normalized_data.get("total_return"))
+            benchmark_return = _safe_float(normalized_data.get("benchmark_return")) or 0.0
+            volatility = _safe_float(normalized_data.get("volatility"))
+            max_drawdown = _safe_float(normalized_data.get("max_drawdown"))
+            win_rate = _safe_float(normalized_data.get("win_rate"))
+            average_trade = _safe_float(normalized_data.get("avg_trade"))
+            largest_win = _safe_float(normalized_data.get("largest_win")) or 0.0
+            largest_loss = _safe_float(normalized_data.get("largest_loss")) or 0.0
+
+            if any(metric is None for metric in [total_return, volatility, max_drawdown, win_rate, average_trade]):
+                perf_result["performance_metrics"] = {}
+                perf_result["risk_adjusted_metrics"] = {}
+                perf_result["benchmark_comparison"] = {}
+                perf_result["attribution_analysis"] = {}
+                perf_result["optimization_recommendations"] = []
+                perf_result["status"] = "insufficient_data"
+                perf_result["error"] = "Missing required performance metrics"
+                return perf_result
 
             period_days = max(1, self._get_period_days_safe(analysis_period))
             annualized_return = total_return * (365 / period_days)
@@ -4971,13 +4964,11 @@ class TradingStrategiesService(LoggerMixin):
                 "max_drawdown_pct": max_drawdown * 100,
                 "recovery_time_days": strategy_data.get("recovery_time", 12),
                 "winning_trades_pct": win_rate * 100,
-                "profit_factor": strategy_data.get("profit_factor", 1.75),
+                "profit_factor": _safe_float(strategy_data.get("profit_factor")) or 0.0,
                 "average_trade_return": average_trade * 100,
                 "largest_win": largest_win * 100,
                 "largest_loss": largest_loss * 100
             }
-
-            perf_result["unit_metadata"] = unit_flags
 
             # Risk-adjusted metrics
             risk_free_rate = 0.05  # 5% risk-free rate

--- a/tests/test_data_quality_guardrails.py
+++ b/tests/test_data_quality_guardrails.py
@@ -1,0 +1,101 @@
+import asyncio
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+import types
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+if "aiosqlite" not in sys.modules:
+    import sqlite3
+
+    stub_aiosqlite = types.ModuleType("aiosqlite")
+    stub_aiosqlite.connect = None  # pragma: no cover - placeholder for SQLAlchemy import
+    for attr in (
+        "DatabaseError",
+        "Error",
+        "IntegrityError",
+        "NotSupportedError",
+        "OperationalError",
+        "ProgrammingError",
+    ):
+        setattr(stub_aiosqlite, attr, getattr(sqlite3, attr))
+    stub_aiosqlite.sqlite_version = sqlite3.sqlite_version
+    stub_aiosqlite.sqlite_version_info = sqlite3.sqlite_version_info
+    stub_aiosqlite.PARSE_COLNAMES = sqlite3.PARSE_COLNAMES
+    stub_aiosqlite.PARSE_DECLTYPES = sqlite3.PARSE_DECLTYPES
+    stub_aiosqlite.Binary = sqlite3.Binary
+    sys.modules["aiosqlite"] = stub_aiosqlite
+
+from app.services import trading_strategies
+from app.services.market_analysis_core import MarketAnalysisService
+from app.services.trading_strategies import TradingStrategiesService
+
+
+class _StubSession:
+    async def __aenter__(self) -> "_StubSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def execute(self, _statement: Any) -> "_StubResult":
+        return _StubResult()
+
+
+class _StubResult:
+    def first(self):
+        return None
+
+    def scalars(self):
+        return self
+
+
+class _StubExecutor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _StubAnalyzer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_strategy_performance_requires_real_data(monkeypatch):
+    monkeypatch.setattr(trading_strategies, "TradeExecutionService", _StubExecutor)
+    monkeypatch.setattr(trading_strategies, "MarketAnalysisService", _StubAnalyzer)
+    monkeypatch.setattr(trading_strategies, "AsyncSessionLocal", lambda: _StubSession())
+
+    service = TradingStrategiesService()
+
+    data = await service._get_strategy_performance_data(None, "30d", "test-user")
+    assert data["data_quality"] == "no_data"
+    assert "total_return" not in data
+
+    summary = await service.strategy_performance(None, "30d", user_id="test-user")
+    assert summary["data_quality"] == "no_data"
+    assert summary["status"] == "no_data_available"
+    assert summary["performance_metrics"] == {}
+    assert summary.get("error")
+
+
+@pytest.mark.asyncio
+async def test_technical_analysis_marks_missing_data(monkeypatch):
+    service = MarketAnalysisService()
+
+    async def _no_data(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(service, "_get_historical_price_data", _no_data)
+
+    result = await service.technical_analysis("BTC/USDT")
+    assert result["success"] is False
+    symbol_payload = result["data"]["BTC/USDT"]
+    assert symbol_payload["data_quality"] == "no_data"
+    assert symbol_payload["analysis"] == {}
+    assert symbol_payload["signals"] == {}


### PR DESCRIPTION
## Summary
- ensure the market analysis service reports failure when technical analysis only has synthetic fallbacks and stop generating fake candle histories
- flag strategy performance responses with their true data quality and refuse to build performance metrics when no verified trades or backtests exist
- add regression coverage that stubs the database and market data layers to confirm the services no longer fabricate placeholder statistics

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///./test.db pytest tests/test_data_quality_guardrails.py`

------
https://chatgpt.com/codex/tasks/task_e_68d0b8b2ccbc83228abef60583ccf344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added per-symbol data_quality flags and consolidated overall success/availability metadata in analysis and performance outputs.
  - Strategy outputs now include raw_performance and unit metadata alongside status and data_quality.

- Bug Fixes / Refactor
  - Removed synthetic fallback data and emit warnings when real market data is absent.
  - Centralized data-quality handling to avoid downstream errors and return concise no-data/error payloads.

- Tests
  - Added tests for data-quality guardrails covering no-data and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->