### PR TITLE
Fix chat database session acquisition to restore live data

### DIFF
--- a/app/services/strategy_marketplace_service.py
+++ b/app/services/strategy_marketplace_service.py
@@ -22,7 +22,7 @@ from sqlalchemy import select, and_, desc, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
-from app.core.database import get_database
+from app.core.database import get_database_session
 from app.core.logging import LoggerMixin
 from app.core.async_session_manager import DatabaseSessionMixin
 from app.models.trading import TradingStrategy, Trade
@@ -1179,7 +1179,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
     async def _get_community_strategies(self, user_id: str) -> List[StrategyMarketplaceItem]:
         """Get community-published strategies."""
         try:
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Get published strategies from community
                 stmt = select(TradingStrategy, StrategyPublisher).join(
                     StrategyPublisher, TradingStrategy.user_id == StrategyPublisher.user_id
@@ -1292,7 +1292,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
     async def _get_live_performance(self, strategy_id: str) -> Dict[str, Any]:
         """Get live performance metrics for strategy."""
         try:
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Get recent trades for this strategy
                 stmt = select(Trade).where(
                     and_(
@@ -1350,7 +1350,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
     ) -> Dict[str, Any]:
         """Purchase access to strategy using credits."""
         try:
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Get user's credit account
                 credit_stmt = select(CreditAccount).where(CreditAccount.user_id == user_id)
                 credit_result = await db.execute(credit_stmt)
@@ -1574,11 +1574,11 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
 
         # ADMIN BYPASS: For admin users, check if we should use fast database path
         try:
-            from app.core.database import get_database
+            from app.core.database import get_database_session
             from app.models.user import User, UserRole
             from sqlalchemy import select
 
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Check if this is an admin user (convert string UUID to proper UUID)
                 import uuid
                 try:

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -846,6 +846,40 @@ class UnifiedChatService(LoggerMixin):
             # Market risk integration pending
             context_data["market_risk"] = {"factors": [], "error": "Market risk integration pending"}
             
+        elif intent == ChatIntent.STRATEGY_MANAGEMENT:
+            user_strategies = context_data.get("user_strategies", {})
+            marketplace_strategies = context_data.get("marketplace_strategies", {})
+
+            if user_strategies.get("success", False):
+                active_strategies = user_strategies.get("active_strategies", [])
+                total_strategies = user_strategies.get("total_strategies", 0)
+                total_monthly_cost = user_strategies.get("total_monthly_cost", 0)
+
+                return f"""User asked: "{message}"
+
+CURRENT STRATEGY PORTFOLIO:
+- Total Active Strategies: {total_strategies}
+- Monthly Cost: {total_monthly_cost} credits
+- Active Strategies: {[s.get('name', 'Unknown') for s in active_strategies[:10]]}
+
+STRATEGY DETAILS:
+{chr(10).join([f"• {s.get('name', 'Unknown')} - {s.get('category', 'Unknown')} - {s.get('credit_cost_monthly', 0)} credits/month" for s in active_strategies[:10]])}
+
+MARKETPLACE SUMMARY:
+- Available Strategies: {len(marketplace_strategies.get('strategies', []))} total strategies
+
+Provide a comprehensive overview of the user's strategy portfolio, subscription status, and actionable recommendations for strategy management."""
+            else:
+                error = user_strategies.get("error", "Unknown error")
+                return f"""User asked: "{message}"
+
+STRATEGY ACCESS STATUS:
+- Current Access: Limited or None
+- Error: {error}
+- Available Marketplace Strategies: {len(marketplace_strategies.get('strategies', []))}
+
+Explain that strategy access requires subscription/purchase and guide the user on how to get started with strategies."""
+
         elif intent == ChatIntent.STRATEGY_RECOMMENDATION:
             # Get strategy recommendations with error handling
             try:
@@ -1167,10 +1201,10 @@ Analyze this trade request and provide recommendations. If viable, explain the 5
             # Group opportunities by strategy
             opportunities_by_strategy = {}
             for opp in opportunities:
-            strategy = opp.get('strategy_name', 'Unknown')
-            if strategy not in opportunities_by_strategy:
-            opportunities_by_strategy[strategy] = []
-            opportunities_by_strategy[strategy].append(opp)
+                strategy = opp.get('strategy_name', 'Unknown')
+                if strategy not in opportunities_by_strategy:
+                    opportunities_by_strategy[strategy] = []
+                opportunities_by_strategy[strategy].append(opp)
             
             # Build comprehensive prompt
             prompt_parts = [f'User asked: "{message}"']
@@ -1180,41 +1214,42 @@ Analyze this trade request and provide recommendations. If viable, explain the 5
             
             # Strategy performance summary
             if strategy_performance:
-            prompt_parts.append("\n📊 STRATEGY PERFORMANCE:")
-            for strat, perf in strategy_performance.items():
-            count = perf.get('count', 0) if isinstance(perf, dict) else perf
-            prompt_parts.append(f"- {strat}: {count} opportunities")
+                prompt_parts.append("\n📊 STRATEGY PERFORMANCE:")
+                for strat, perf in strategy_performance.items():
+                    count = perf.get('count', 0) if isinstance(perf, dict) else perf
+                    prompt_parts.append(f"- {strat}: {count} opportunities")
             
             # Detailed opportunities by strategy
             prompt_parts.append("\n🎯 OPPORTUNITIES BY STRATEGY:")
             for strategy, opps in opportunities_by_strategy.items():
-            prompt_parts.append(f"\n{strategy} ({len(opps)} opportunities):")
-            for i, opp in enumerate(opps[:3], 1):  # Show top 3 per strategy
-            symbol = opp.get('symbol', 'N/A')
-            confidence = opp.get('confidence_score', 0)
-            profit_usd = opp.get('profit_potential_usd', 0)
-            metadata = opp.get('metadata', {})
-                        # Format based on opportunity type
-            if 'portfolio' in strategy.lower():
-            if metadata.get('strategy'):
-            prompt_parts.append(f"  {i}. {metadata['strategy'].replace('_', ' ').title()}")
-            prompt_parts.append(f"     Expected Return: {metadata.get('expected_annual_return', 0)*100:.1f}%")
-            prompt_parts.append(f"     Sharpe Ratio: {metadata.get('sharpe_ratio', 0):.2f}")
-            prompt_parts.append(f"     Risk Level: {metadata.get('risk_level', 0)*100:.1f}%")
-            else:
-            prompt_parts.append(f"  {i}. {symbol} - {metadata.get('rebalance_action', 'REBALANCE')}")
-            prompt_parts.append(f"     Amount: {metadata.get('amount', 0)*100:.1f}% of portfolio")
-            elif 'risk' in strategy.lower():
-            prompt_parts.append(f"  {i}. {metadata.get('risk_type', 'Risk Alert')}")
-            prompt_parts.append(f"     Action: {metadata.get('strategy', 'Mitigation needed')}")
-            prompt_parts.append(f"     Urgency: {metadata.get('urgency', confidence/100)}")
-            else:
-            prompt_parts.append(f"  {i}. {symbol}")
-            prompt_parts.append(f"     Confidence: {confidence:.1f}%")
-            prompt_parts.append(f"     Profit Potential: ${profit_usd:,.0f}")
-            action = metadata.get('signal_action', opp.get('action', 'ANALYZE'))
-            if action:
-            prompt_parts.append(f"     Action: {action}")
+                prompt_parts.append(f"\n{strategy} ({len(opps)} opportunities):")
+                for i, opp in enumerate(opps[:3], 1):  # Show top 3 per strategy
+                    symbol = opp.get('symbol', 'N/A')
+                    confidence = opp.get('confidence_score', 0)
+                    profit_usd = opp.get('profit_potential_usd', 0)
+                    metadata = opp.get('metadata', {})
+
+                    # Format based on opportunity type
+                    if 'portfolio' in strategy.lower():
+                        if metadata.get('strategy'):
+                            prompt_parts.append(f"  {i}. {metadata['strategy'].replace('_', ' ').title()}")
+                            prompt_parts.append(f"     Expected Return: {metadata.get('expected_annual_return', 0)*100:.1f}%")
+                            prompt_parts.append(f"     Sharpe Ratio: {metadata.get('sharpe_ratio', 0):.2f}")
+                            prompt_parts.append(f"     Risk Level: {metadata.get('risk_level', 0)*100:.1f}%")
+                        else:
+                            prompt_parts.append(f"  {i}. {symbol} - {metadata.get('rebalance_action', 'REBALANCE')}")
+                            prompt_parts.append(f"     Amount: {metadata.get('amount', 0)*100:.1f}% of portfolio")
+                    elif 'risk' in strategy.lower():
+                        prompt_parts.append(f"  {i}. {metadata.get('risk_type', 'Risk Alert')}")
+                        prompt_parts.append(f"     Action: {metadata.get('strategy', 'Mitigation needed')}")
+                        prompt_parts.append(f"     Urgency: {metadata.get('urgency', confidence/100)}")
+                    else:
+                        prompt_parts.append(f"  {i}. {symbol}")
+                        prompt_parts.append(f"     Confidence: {confidence:.1f}%")
+                        prompt_parts.append(f"     Profit Potential: ${profit_usd:,.0f}")
+                        action = metadata.get('signal_action', opp.get('action', 'ANALYZE'))
+                        if action:
+                            prompt_parts.append(f"     Action: {action}")
             
             prompt_parts.append(f"""
             
@@ -1236,11 +1271,11 @@ Remember: You are the AI Money Manager providing personalized advice based on re
             marketplace_strategies = context_data.get("marketplace_strategies", {})
 
             if user_strategies.get("success", False):
-            active_strategies = user_strategies.get("active_strategies", [])
-            total_strategies = user_strategies.get("total_strategies", 0)
-            total_monthly_cost = user_strategies.get("total_monthly_cost", 0)
+                active_strategies = user_strategies.get("active_strategies", [])
+                total_strategies = user_strategies.get("total_strategies", 0)
+                total_monthly_cost = user_strategies.get("total_monthly_cost", 0)
 
-            return f"""User asked: "{message}"
+                return f"""User asked: "{message}"
 
 CURRENT STRATEGY PORTFOLIO:
 - Total Active Strategies: {total_strategies}
@@ -1255,8 +1290,8 @@ MARKETPLACE SUMMARY:
 
 Provide a comprehensive overview of the user's strategy portfolio, subscription status, and actionable recommendations for strategy management."""
             else:
-            error = user_strategies.get("error", "Unknown error")
-            return f"""User asked: "{message}"
+                error = user_strategies.get("error", "Unknown error")
+                return f"""User asked: "{message}"
 
 STRATEGY ACCESS STATUS:
 - Current Access: Limited or None
@@ -1384,20 +1419,20 @@ Provide a helpful response using the real data available. Never use placeholder 
         try:
             redis = await self._ensure_redis()
             if redis:
-            decision_data = {
-            "decision_id": decision_id,
-            "user_id": user_id,
-            "intent": intent_analysis["intent"].value,
-            "context_data": context_data,
-            "conversation_mode": conversation_mode.value,
-            "created_at": datetime.utcnow().isoformat(),
-            "expires_at": (datetime.utcnow() + timedelta(minutes=5)).isoformat()
-            }
-            await redis.setex(
-            f"pending_decision:{decision_id}",
-            300,  # 5 minute expiry
-            json.dumps(decision_data)
-            )
+                decision_data = {
+                    "decision_id": decision_id,
+                    "user_id": user_id,
+                    "intent": intent_analysis["intent"].value,
+                    "context_data": context_data,
+                    "conversation_mode": conversation_mode.value,
+                    "created_at": datetime.utcnow().isoformat(),
+                    "expires_at": (datetime.utcnow() + timedelta(minutes=5)).isoformat()
+                }
+                await redis.setex(
+                    f"pending_decision:{decision_id}",
+                    300,  # 5 minute expiry
+                    json.dumps(decision_data)
+                )
         except Exception as e:
             self.logger.error("Failed to store pending decision", error=str(e))
     
@@ -1416,54 +1451,54 @@ Provide a helpful response using the real data available. Never use placeholder 
             # Retrieve pending decision
             redis = await self._ensure_redis()
             if not redis:
-            return {"success": False, "error": "Decision storage not available"}
-            
+                return {"success": False, "error": "Decision storage not available"}
+
             decision_data = await redis.get(f"pending_decision:{decision_id}")
             if not decision_data:
-            return {"success": False, "error": "Decision not found or expired"}
-            
+                return {"success": False, "error": "Decision not found or expired"}
+
             decision = json.loads(decision_data)
 
             conversation_mode = None
             conversation_mode_value = decision.get("conversation_mode")
             if conversation_mode_value:
-            try:
-            conversation_mode = ConversationMode(conversation_mode_value)
-            except ValueError:
-            conversation_mode = None
+                try:
+                    conversation_mode = ConversationMode(conversation_mode_value)
+                except ValueError:
+                    conversation_mode = None
 
             # Verify user
             if decision["user_id"] != user_id:
-            return {"success": False, "error": "Unauthorized"}
-            
+                return {"success": False, "error": "Unauthorized"}
+
             if not approved:
-            return {"success": True, "message": "Decision rejected by user"}
-            
+                return {"success": True, "message": "Decision rejected by user"}
+
             # Execute based on intent
             intent = ChatIntent(decision["intent"])
             context_data = decision["context_data"]
-            
+
             if intent == ChatIntent.TRADE_EXECUTION:
-            # 5-PHASE EXECUTION PRESERVED
-            return await self._execute_trade_with_validation(
-            context_data.get("trade_validation", {}),
-            user_id,
-            modifications,
-            conversation_mode=conversation_mode,
-            context_data=context_data
-            )
-            
+                # 5-PHASE EXECUTION PRESERVED
+                return await self._execute_trade_with_validation(
+                    context_data.get("trade_validation", {}),
+                    user_id,
+                    modifications,
+                    conversation_mode=conversation_mode,
+                    context_data=context_data
+                )
+
             elif intent == ChatIntent.REBALANCING:
-            # Execute rebalancing
-            return await self._execute_rebalancing(
-            context_data.get("rebalance_analysis", {}),
-            user_id,
-            modifications
-            )
-            
+                # Execute rebalancing
+                return await self._execute_rebalancing(
+                    context_data.get("rebalance_analysis", {}),
+                    user_id,
+                    modifications
+                )
+
             else:
-            return {"success": False, "error": f"Unknown decision type: {intent}"}
-                    except Exception as e:
+                return {"success": False, "error": f"Unknown decision type: {intent}"}
+        except Exception as e:
             self.logger.exception("Decision execution failed", error=str(e))
             return {"success": False, "error": str(e)}
     
@@ -1493,14 +1528,14 @@ Provide a helpful response using the real data available. Never use placeholder 
         simulation_mode = self._coerce_to_bool(trade_payload.get("simulation_mode"), True)
         try:
             missing_fields = [
-            field for field in ("symbol", "action") if not trade_params.get(field)
+                field for field in ("symbol", "action") if not trade_params.get(field)
             ]
             if missing_fields:
-            return {
-            "success": False,
-            "message": f"Missing required trade parameters: {', '.join(missing_fields)}",
-            "phases_completed": phases_completed
-            }
+                return {
+                    "success": False,
+                    "message": f"Missing required trade parameters: {', '.join(missing_fields)}",
+                    "phases_completed": phases_completed
+                }
 
             # Phase 1: Analysis
             self.logger.info("Phase 1: Trade Analysis", trade=trade_payload)
@@ -1518,12 +1553,12 @@ Provide a helpful response using the real data available. Never use placeholder 
             phases_completed.append("consensus")
 
             if not consensus.get("approved", False):
-            return {
-            "success": False,
-            "message": "Trade rejected by AI consensus",
-            "reason": consensus.get("reason", "Risk threshold exceeded"),
-            "phases_completed": phases_completed
-            }
+                return {
+                    "success": False,
+                    "message": "Trade rejected by AI consensus",
+                    "reason": consensus.get("reason", "Risk threshold exceeded"),
+                    "phases_completed": phases_completed
+                }
 
             # Phase 3: Validation
             self.logger.info("Phase 3: Trade Validation")
@@ -1536,18 +1571,18 @@ Provide a helpful response using the real data available. Never use placeholder 
 
             # Ensure basic action mapping for validator
             if "action" not in trade_request and "side" in trade_request:
-            trade_request["action"] = trade_request["side"]
+                trade_request["action"] = trade_request["side"]
 
             validation = await self.trade_executor.validate_trade(trade_request, user_id)
             phases_completed.append("validation")
 
             if not validation.get("valid", False):
-            return {
-            "success": False,
-            "message": "Trade validation failed",
-            "reason": validation.get("reason", "Invalid parameters"),
-            "phases_completed": phases_completed
-            }
+                return {
+                    "success": False,
+                    "message": "Trade validation failed",
+                    "reason": validation.get("reason", "Invalid parameters"),
+                    "phases_completed": phases_completed
+                }
 
             trade_request = validation.get("trade_request", trade_request)
             trade_request.setdefault("side", trade_request.get("action", "BUY").lower())
@@ -1556,113 +1591,113 @@ Provide a helpful response using the real data available. Never use placeholder 
             self.logger.info("Phase 4: Trade Execution")
 
             if conversation_mode == ConversationMode.PAPER_TRADING:
-            quantity = trade_params.get("quantity")
-            notional_amount = trade_params.get("amount") or trade_params.get("position_size_usd")
+                quantity = trade_params.get("quantity")
+                notional_amount = trade_params.get("amount") or trade_params.get("position_size_usd")
 
-            if not quantity and notional_amount and market_data.get("current_price"):
-            try:
-            quantity = float(notional_amount) / float(market_data["current_price"])
-            except (TypeError, ZeroDivisionError):
-            quantity = None
+                if not quantity and notional_amount and market_data.get("current_price"):
+                    try:
+                        quantity = float(notional_amount) / float(market_data["current_price"])
+                    except (TypeError, ZeroDivisionError):
+                        quantity = None
 
-            if quantity is None:
-            return {
-            "success": False,
-            "message": "Unable to determine trade quantity for paper trading",
-            "phases_completed": phases_completed
-            }
+                if quantity is None:
+                    return {
+                        "success": False,
+                        "message": "Unable to determine trade quantity for paper trading",
+                        "phases_completed": phases_completed
+                    }
 
-            paper_result = await self.paper_trading.execute_paper_trade(
-            user_id=user_id,
-            symbol=trade_params["symbol"],
-            side=trade_params["action"],
-            quantity=quantity,
-            strategy_used=trade_params.get("strategy", "chat_trade"),
-            order_type=trade_params.get("order_type", "market")
-            )
-            phases_completed.append("execution")
+                paper_result = await self.paper_trading.execute_paper_trade(
+                    user_id=user_id,
+                    symbol=trade_params["symbol"],
+                    side=trade_params["action"],
+                    quantity=quantity,
+                    strategy_used=trade_params.get("strategy", "chat_trade"),
+                    order_type=trade_params.get("order_type", "market")
+                )
+                phases_completed.append("execution")
 
-            if not paper_result.get("success", False):
-            return {
-            "success": False,
-            "message": paper_result.get("error", "Paper trade execution failed"),
-            "phases_completed": phases_completed,
-            "execution_details": paper_result
-            }
+                if not paper_result.get("success", False):
+                    return {
+                        "success": False,
+                        "message": paper_result.get("error", "Paper trade execution failed"),
+                        "phases_completed": phases_completed,
+                        "execution_details": paper_result
+                    }
 
-            monitoring = {"monitoring_active": False, "paper_trading": True}
-            phases_completed.append("monitoring")
+                monitoring = {"monitoring_active": False, "paper_trading": True}
+                phases_completed.append("monitoring")
 
-            return {
-            "success": True,
-            "message": paper_result.get("message", "Paper trade executed successfully"),
-            "trade_id": paper_result.get("paper_trade", {}).get("trade_id"),
-            "phases_completed": phases_completed,
-            "execution_details": paper_result,
-            "monitoring_details": monitoring
-            }
-
-            simulation_mode = await self._get_user_simulation_mode(user_id)
-            if simulation_mode is None:
-            simulation_mode = True
-
-            trade_request = self._build_trade_request_for_execution(trade_params, market_data)
-            if not trade_request.get("symbol") or not trade_request.get("action"):
-            return {
-            "success": False,
-            "message": "Unable to build trade request for execution",
-            "phases_completed": phases_completed
-            }
-
-            execution = await self.trade_executor.execute_trade(
-            trade_request,
-            user_id,
-            simulation_mode
-            )
-            phases_completed.append("execution")
-
-            if not execution.get("success", False):
-            return {
-            "success": False,
-            "message": "Trade execution failed",
-            "reason": execution.get("error", "Unknown error"),
-            "phases_completed": phases_completed
-            }
-
-            trade_id = execution.get("trade_id")
-            simulation_identifier = execution.get("simulation_result", {}).get("order_id")
-            derived_trade_id = trade_id or simulation_identifier
-
-            if trade_id:
-            # Phase 5: Monitoring
-            self.logger.info("Phase 5: Trade Monitoring")
-            monitoring = await self._initiate_trade_monitoring(
-            trade_id,
-            user_id
-            )
-            phases_completed.append("monitoring")
+                return {
+                    "success": True,
+                    "message": paper_result.get("message", "Paper trade executed successfully"),
+                    "trade_id": paper_result.get("paper_trade", {}).get("trade_id"),
+                    "phases_completed": phases_completed,
+                    "execution_details": paper_result,
+                    "monitoring_details": monitoring
+                }
             else:
-            monitoring = {
-            "monitoring_active": False,
-            "reason": "Trade monitoring skipped - no trade ID available",
-            "simulation": simulation_identifier is not None
-            }
+                simulation_mode = await self._get_user_simulation_mode(user_id)
+                if simulation_mode is None:
+                    simulation_mode = True
 
-            return {
-            "success": True,
-            "message": execution.get("message", "Trade executed successfully"),
-            "trade_id": derived_trade_id,
-            "phases_completed": phases_completed,
-            "execution_details": execution,
-            "monitoring_details": monitoring
-            }
+                trade_request = self._build_trade_request_for_execution(trade_params, market_data)
+                if not trade_request.get("symbol") or not trade_request.get("action"):
+                    return {
+                        "success": False,
+                        "message": "Unable to build trade request for execution",
+                        "phases_completed": phases_completed
+                    }
+
+                execution = await self.trade_executor.execute_trade(
+                    trade_request,
+                    user_id,
+                    simulation_mode
+                )
+                phases_completed.append("execution")
+
+                if not execution.get("success", False):
+                    return {
+                        "success": False,
+                        "message": "Trade execution failed",
+                        "reason": execution.get("error", "Unknown error"),
+                        "phases_completed": phases_completed
+                    }
+
+                trade_id = execution.get("trade_id")
+                simulation_identifier = execution.get("simulation_result", {}).get("order_id")
+                derived_trade_id = trade_id or simulation_identifier
+
+                if trade_id:
+                    # Phase 5: Monitoring
+                    self.logger.info("Phase 5: Trade Monitoring")
+                    monitoring = await self._initiate_trade_monitoring(
+                        trade_id,
+                        user_id
+                    )
+                    phases_completed.append("monitoring")
+                else:
+                    monitoring = {
+                        "monitoring_active": False,
+                        "reason": "Trade monitoring skipped - no trade ID available",
+                        "simulation": simulation_identifier is not None
+                    }
+
+                return {
+                    "success": True,
+                    "message": execution.get("message", "Trade executed successfully"),
+                    "trade_id": derived_trade_id,
+                    "phases_completed": phases_completed,
+                    "execution_details": execution,
+                    "monitoring_details": monitoring
+                }
 
         except Exception as e:
             self.logger.exception("Trade execution error", error=str(e))
             return {
-            "success": False,
-            "error": str(e),
-            "phases_completed": phases_completed
+                "success": False,
+                "error": str(e),
+                "phases_completed": phases_completed
             }
 
     async def _get_user_simulation_mode(self, user_id: str) -> Optional[bool]:
@@ -1670,23 +1705,23 @@ Provide a helpful response using the real data available. Never use placeholder 
         try:
             user_identifier: Any = user_id
             try:
-            user_identifier = uuid.UUID(str(user_id))
+                user_identifier = uuid.UUID(str(user_id))
             except (ValueError, TypeError):
-            user_identifier = user_id
+                user_identifier = user_id
 
             async with AsyncSessionLocal() as session:
-            result = await session.execute(
-            select(User.simulation_mode).where(User.id == user_identifier)
-            )
-            value = result.scalar_one_or_none()
-            if value is None:
-            return None
-            return bool(value)
+                result = await session.execute(
+                    select(User.simulation_mode).where(User.id == user_identifier)
+                )
+                value = result.scalar_one_or_none()
+                if value is None:
+                    return None
+                return bool(value)
         except Exception as exc:
             self.logger.warning(
-            "Failed to fetch user simulation mode",
-            error=str(exc),
-            user_id=str(user_id)
+                "Failed to fetch user simulation mode",
+                error=str(exc),
+                user_id=str(user_id)
             )
             return None
 
@@ -1723,12 +1758,12 @@ Provide a helpful response using the real data available. Never use placeholder 
             trade_request["position_size_usd"] = amount
             price = market_data.get("current_price")
             if price:
-            try:
-            quantity = float(amount) / float(price)
-            if quantity > 0:
-            trade_request.setdefault("quantity", quantity)
-            except (TypeError, ZeroDivisionError):
-            pass
+                try:
+                    quantity = float(amount) / float(price)
+                    if quantity > 0:
+                        trade_request.setdefault("quantity", quantity)
+                except (TypeError, ZeroDivisionError):
+                    pass
 
         for optional_key in [
             "price",
@@ -1740,7 +1775,7 @@ Provide a helpful response using the real data available. Never use placeholder 
             "strategy"
         ]:
             if optional_key in trade_params and trade_params[optional_key] is not None:
-            trade_request[optional_key] = trade_params[optional_key]
+                trade_request[optional_key] = trade_params[optional_key]
 
         action_value = trade_request.get("action")
         if isinstance(action_value, str) and action_value:
@@ -1758,81 +1793,85 @@ Provide a helpful response using the real data available. Never use placeholder 
         try:
             trades = rebalance_analysis.get("recommended_trades", [])
             if modifications:
-            # Apply any user modifications to trades
-            pass
-            
-            results = []
+                # Apply any user modifications to trades
+                pass
+
+            results: List[Dict[str, Any]] = []
             for trade in trades:
-            base_request = {
-            "symbol": trade.get("symbol"),
-            "action": trade.get("action") or trade.get("side"),
-            "amount": trade.get("amount"),
-            "quantity": trade.get("quantity", trade.get("amount")),
-            "order_type": trade.get("order_type", "market"),
-            "price": trade.get("price"),
-            "exchange": trade.get("exchange"),
-            "stop_loss": trade.get("stop_loss"),
-            "take_profit": trade.get("take_profit"),
-            }
+                base_request = {
+                    "symbol": trade.get("symbol"),
+                    "action": trade.get("action") or trade.get("side"),
+                    "amount": trade.get("amount"),
+                    "quantity": trade.get("quantity", trade.get("amount")),
+                    "order_type": trade.get("order_type", "market"),
+                    "price": trade.get("price"),
+                    "exchange": trade.get("exchange"),
+                    "stop_loss": trade.get("stop_loss"),
+                    "take_profit": trade.get("take_profit"),
+                }
 
-            base_request = {k: v for k, v in base_request.items() if v is not None}
+                base_request = {k: v for k, v in base_request.items() if v is not None}
 
-            if "action" not in base_request and "side" in base_request:
-            base_request["action"] = base_request["side"]
+                if "action" not in base_request and "side" in base_request:
+                    base_request["action"] = base_request["side"]
 
-            try:
-            validation = await self.trade_executor.validate_trade(dict(base_request), user_id)
-            except Exception as validation_error:
-            self.logger.exception(
-            "Rebalancing trade validation crashed",
-            error=str(validation_error),
-            trade=base_request
-            )
-            results.append({
-            "success": False,
-            "error": str(validation_error),
-            "trade_request": base_request
-            })
-            continue
+                try:
+                    validation = await self.trade_executor.validate_trade(dict(base_request), user_id)
+                except Exception as validation_error:
+                    self.logger.exception(
+                        "Rebalancing trade validation crashed",
+                        error=str(validation_error),
+                        trade=base_request,
+                    )
+                    results.append(
+                        {
+                            "success": False,
+                            "error": str(validation_error),
+                            "trade_request": base_request,
+                        }
+                    )
+                    continue
 
-            if not validation.get("valid", False):
-            results.append({
-            "success": False,
-            "error": validation.get("reason", "Invalid parameters"),
-            "trade_request": validation.get("trade_request", base_request)
-            })
-            continue
+                if not validation.get("valid", False):
+                    results.append(
+                        {
+                            "success": False,
+                            "error": validation.get("reason", "Invalid parameters"),
+                            "trade_request": validation.get("trade_request", base_request),
+                        }
+                    )
+                    continue
 
-            normalized_request = validation.get("trade_request", base_request)
-            normalized_request.setdefault(
-            "side",
-            normalized_request.get("action", "BUY").lower()
-            )
+                normalized_request = validation.get("trade_request", base_request)
+                normalized_request.setdefault(
+                    "side",
+                    normalized_request.get("action", "BUY").lower(),
+                )
 
-            simulation_mode = self._coerce_to_bool(trade.get("simulation_mode"), True)
+                simulation_mode = self._coerce_to_bool(trade.get("simulation_mode"), True)
 
-            result = await self.trade_executor.execute_trade(
-            normalized_request,
-            user_id,
-            simulation_mode
-            )
-            results.append(result)
-            
+                result = await self.trade_executor.execute_trade(
+                    normalized_request,
+                    user_id,
+                    simulation_mode,
+                )
+                results.append(result)
+
             return {
-            "success": True,
-            "message": "Rebalancing executed successfully",
-            "trades_executed": len([r for r in results if r.get("success")]),
-            "trades_failed": len([r for r in results if not r.get("success")]),
-            "results": results
+                "success": True,
+                "message": "Rebalancing executed successfully",
+                "trades_executed": len([r for r in results if r.get("success")]),
+                "trades_failed": len([r for r in results if not r.get("success")]),
+                "results": results,
             }
-            
+
         except Exception as e:
             self.logger.exception("Rebalancing execution error", error=str(e))
             return {
-            "success": False,
-            "error": str(e)
+                "success": False,
+                "error": str(e),
             }
-    
+
     async def _initiate_trade_monitoring(
         self,
         trade_id: str,
@@ -1842,15 +1881,15 @@ Provide a helpful response using the real data available. Never use placeholder 
         try:
             # Set up monitoring alerts, stop losses, etc.
             return {
-            "monitoring_active": True,
-            "trade_id": trade_id,
-            "alerts_configured": True
+                "monitoring_active": True,
+                "trade_id": trade_id,
+                "alerts_configured": True
             }
         except Exception as e:
             self.logger.error("Failed to initiate monitoring", error=str(e))
             return {
-            "monitoring_active": False,
-            "error": str(e)
+                "monitoring_active": False,
+                "error": str(e)
             }
     
     async def _save_conversation(
@@ -1866,20 +1905,20 @@ Provide a helpful response using the real data available. Never use placeholder 
         try:
             # Save user message
             await self.memory_service.add_message(
-            session_id=session_id,
-            user_id=user_id,
-            message_type=ChatMessageType.USER,
-            content=user_message,
-            metadata={"intent": intent.value, "confidence": confidence}
+                session_id=session_id,
+                user_id=user_id,
+                message_type=ChatMessageType.USER,
+                content=user_message,
+                metadata={"intent": intent.value, "confidence": confidence}
             )
-            
+
             # Save assistant response
             await self.memory_service.add_message(
-            session_id=session_id,
-            user_id=user_id,
-            message_type=ChatMessageType.ASSISTANT,
-            content=assistant_message,
-            metadata={"intent": intent.value}
+                session_id=session_id,
+                user_id=user_id,
+                message_type=ChatMessageType.ASSISTANT,
+                content=assistant_message,
+                metadata={"intent": intent.value}
             )
         except Exception as e:
             self.logger.error("Failed to save conversation", error=str(e))
@@ -1928,9 +1967,9 @@ Provide a helpful response using the real data available. Never use placeholder 
         active_sessions = []
         for session_id, session in self.sessions.items():
             if session.user_id == user_id:
-            # Consider session active if used in last 24 hours
-            if (datetime.utcnow() - session.last_activity).total_seconds() < 86400:
-            active_sessions.append(session_id)
+                # Consider session active if used in last 24 hours
+                if (datetime.utcnow() - session.last_activity).total_seconds() < 86400:
+                    active_sessions.append(session_id)
         return active_sessions
     
     async def get_service_status(self) -> Dict[str, Any]:
@@ -1942,18 +1981,18 @@ Provide a helpful response using the real data available. Never use placeholder 
             "chat_ai_status": await self.chat_ai.get_service_status(),
             "ai_consensus_status": "operational",  # Only for trades
             "connected_services": {
-            "market_analysis": "connected",
-            "portfolio_risk": "connected",
-            "trade_execution": "connected",
-            "strategy_marketplace": "connected",
-            "paper_trading": "connected"
+                "market_analysis": "connected",
+                "portfolio_risk": "connected",
+                "trade_execution": "connected",
+                "strategy_marketplace": "connected",
+                "paper_trading": "connected"
             },
             "features_active": {
-            "credit_validation": True,
-            "strategy_checks": True,
-            "paper_trading_no_credits": True,
-            "5_phase_execution": True,
-            "real_data_only": True
+                "credit_validation": True,
+                "strategy_checks": True,
+                "paper_trading_no_credits": True,
+                "5_phase_execution": True,
+                "real_data_only": True
             }
         }
 

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 
 from app.core.config import get_settings
 from app.core.logging import LoggerMixin
-from app.core.database import AsyncSessionLocal
+from app.core.database import AsyncSessionLocal, get_database_session
 from app.core.redis import get_redis_client
 
 # Import the new ChatAI service for conversations
@@ -577,12 +577,11 @@ class UnifiedChatService(LoggerMixin):
         Uses the same credit lookup logic as the API endpoint.
         """
         try:
-            from app.core.database import get_database
             from app.models.credit import CreditAccount
             from sqlalchemy import select
             import uuid
 
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Try multiple lookup methods to find existing account
                 credit_account = None
 
@@ -700,11 +699,10 @@ class UnifiedChatService(LoggerMixin):
             # Use EXACT same code path as working trading API endpoint
             import asyncio
             from app.api.v1.endpoints.exchanges import get_user_portfolio_from_exchanges
-            from app.core.database import get_database
 
             # Fix: Apply timeout at the correct level to avoid async context conflicts
             async def _fetch_portfolio():
-                async with get_database() as db:
+                async with get_database_session() as db:
                     return await get_user_portfolio_from_exchanges(str(user_id), db)
 
             portfolio_data = await asyncio.wait_for(_fetch_portfolio(), timeout=15.0)

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -846,40 +846,6 @@ class UnifiedChatService(LoggerMixin):
             # Market risk integration pending
             context_data["market_risk"] = {"factors": [], "error": "Market risk integration pending"}
             
-        elif intent == ChatIntent.STRATEGY_MANAGEMENT:
-            user_strategies = context_data.get("user_strategies", {})
-            marketplace_strategies = context_data.get("marketplace_strategies", {})
-
-            if user_strategies.get("success", False):
-                active_strategies = user_strategies.get("active_strategies", [])
-                total_strategies = user_strategies.get("total_strategies", 0)
-                total_monthly_cost = user_strategies.get("total_monthly_cost", 0)
-
-                return f"""User asked: "{message}"
-
-CURRENT STRATEGY PORTFOLIO:
-- Total Active Strategies: {total_strategies}
-- Monthly Cost: {total_monthly_cost} credits
-- Active Strategies: {[s.get('name', 'Unknown') for s in active_strategies[:10]]}
-
-STRATEGY DETAILS:
-{chr(10).join([f"• {s.get('name', 'Unknown')} - {s.get('category', 'Unknown')} - {s.get('credit_cost_monthly', 0)} credits/month" for s in active_strategies[:10]])}
-
-MARKETPLACE SUMMARY:
-- Available Strategies: {len(marketplace_strategies.get('strategies', []))} total strategies
-
-Provide a comprehensive overview of the user's strategy portfolio, subscription status, and actionable recommendations for strategy management."""
-            else:
-                error = user_strategies.get("error", "Unknown error")
-                return f"""User asked: "{message}"
-
-STRATEGY ACCESS STATUS:
-- Current Access: Limited or None
-- Error: {error}
-- Available Marketplace Strategies: {len(marketplace_strategies.get('strategies', []))}
-
-Explain that strategy access requires subscription/purchase and guide the user on how to get started with strategies."""
-
         elif intent == ChatIntent.STRATEGY_RECOMMENDATION:
             # Get strategy recommendations with error handling
             try:


### PR DESCRIPTION
## Summary
- add an application-facing `get_database_session` async context manager for safe session acquisition outside of FastAPI dependencies
- refactor unified chat credit and portfolio helpers to use the shared context manager so they can read live balances again
- update strategy marketplace service entry points to use the same context manager, restoring admin portfolio checks and purchases

## Testing
- `pytest tests/services/test_unified_chat_service.py` *(fails: pre-existing IndentationError in app/services/unified_chat_service.py unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a5e2c560832288e6dfd3bf315124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded conversational strategy flows with richer portfolio/marketplace summaries and per-strategy opportunity formatting.

- Refactor
  - Standardized async database session handling across services for consistent session lifecycle.

- Reliability
  - Automatic rollbacks, guaranteed session closure, and broader error handling/logging to reduce leaks and preserve error context.

- Improvements
  - Safer defaults and clearer handling for trade/rebalance and decision flows.

- Chores
  - Aligned imports and internal usage to the new session management approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->