### PR TITLE
Add regression test for multi-strategy rebalancing output

### DIFF
--- a/app/services/chat_service_adapters_fixed.py
+++ b/app/services/chat_service_adapters_fixed.py
@@ -953,7 +953,7 @@ class ChatServiceAdaptersFixed:
         """AI MONEY MANAGER: Test all strategies and return comprehensive analysis."""
         try:
             logger.info("AI Money Manager: Testing all strategies for optimal selection", user_id=user_id)
-            
+
             # Convert portfolio for optimization
             optimization_portfolio = self._convert_portfolio_for_optimization(portfolio_data)
             
@@ -1047,59 +1047,72 @@ class ChatServiceAdaptersFixed:
             
             # Find the best strategy
             if successful_results:
-                best_strategy = max(successful_results.keys(), 
+                best_strategy = max(successful_results.keys(),
                                   key=lambda k: successful_results[k]["final_score"])
                 best_metrics = successful_results[best_strategy]
-                
+
                 # Sort all results by score for ranking
-                ranked_strategies = sorted(successful_results.items(), 
-                                         key=lambda x: x[1]["final_score"], 
+                ranked_strategies = sorted(successful_results.items(),
+                                         key=lambda x: x[1]["final_score"],
                                          reverse=True)
-                
+
                 logger.info("AI Money Manager: Strategy analysis completed",
                            best_strategy=best_strategy,
                            best_score=best_metrics["final_score"],
                            strategies_tested=len(strategy_results),
                            successful_strategies=len(successful_results))
-                
+
                 return {
+                    "analysis_type": "comprehensive_multi_strategy",
                     "recommended_strategy": best_strategy,
                     "best_metrics": best_metrics,
                     "all_results": strategy_results,
+                    "all_strategies": strategy_results,
                     "ranked_strategies": ranked_strategies,
                     "analysis_summary": {
                         "total_tested": len(strategy_results),
                         "successful": len(successful_results),
                         "failed": len(strategy_results) - len(successful_results)
-                    }
+                    },
+                    "strategies_tested": len(strategy_results),
+                    "successful_strategies": len(successful_results),
+                    "failed_strategies": len(strategy_results) - len(successful_results)
                 }
             else:
                 # All strategies failed - use intelligent fallback
                 fallback_strategy = await self._select_optimal_strategy(portfolio_data, user_id)
-                logger.warning("All strategies failed, using intelligent fallback", 
+                logger.warning("All strategies failed, using intelligent fallback",
                               fallback_strategy=fallback_strategy)
-                
+
                 return {
+                    "analysis_type": "fallback_intelligent_selection",
                     "recommended_strategy": fallback_strategy,
                     "best_metrics": {"expected_return": 0.15, "final_score": 0.1},
                     "all_results": strategy_results,
+                    "all_strategies": strategy_results,
                     "ranked_strategies": [],
                     "analysis_summary": {
                         "total_tested": len(strategy_results),
                         "successful": 0,
                         "failed": len(strategy_results),
                         "fallback_used": True
-                    }
+                    },
+                    "strategies_tested": len(strategy_results),
+                    "successful_strategies": 0,
+                    "failed_strategies": len(strategy_results),
+                    "fallback_used": True
                 }
-                
+
         except Exception as e:
             logger.error("Comprehensive strategy analysis failed", error=str(e))
             # Use existing intelligent selection as fallback
             fallback_strategy = await self._select_optimal_strategy(portfolio_data, user_id)
             return {
+                "analysis_type": "error_fallback",
                 "recommended_strategy": fallback_strategy,
                 "best_metrics": {"expected_return": 0.15, "final_score": 0.1},
                 "all_results": {},
+                "all_strategies": {},
                 "ranked_strategies": [],
                 "analysis_summary": {
                     "total_tested": 0,
@@ -1107,7 +1120,12 @@ class ChatServiceAdaptersFixed:
                     "failed": 0,
                     "error": str(e),
                     "fallback_used": True
-                }
+                },
+                "strategies_tested": 0,
+                "successful_strategies": 0,
+                "failed_strategies": 0,
+                "fallback_used": True,
+                "error": str(e)
             }
     
     def _map_risk_tolerance(self, risk_tolerance: str) -> str:

--- a/app/services/portfolio_risk_core.py
+++ b/app/services/portfolio_risk_core.py
@@ -1013,7 +1013,7 @@ class PortfolioRiskService(LoggerMixin):
     
     def _generate_request_id(self) -> str:
         """Generate unique request ID."""
-        return f"PRMS_{int(time.time())}_{uuid.uuid4().hex[:8]}"
+        return f"PRS_{int(time.time())}_{uuid.uuid4().hex[:8]}"
     
     async def _generate_comprehensive_recommendations(
         self,
@@ -1571,10 +1571,6 @@ class PortfolioRiskService(LoggerMixin):
                 "timestamp": datetime.utcnow().isoformat()
             }
     
-    def _generate_request_id(self) -> str:
-        """Generate unique request ID."""
-        return f"PRS_{int(time.time())}_{uuid.uuid4().hex[:8]}"
-
     def _make_json_serializable(self, obj: Any) -> Any:
         """Convert objects to JSON-serializable format."""
         if isinstance(obj, dict):

--- a/app/services/portfolio_risk_core.py
+++ b/app/services/portfolio_risk_core.py
@@ -1204,9 +1204,9 @@ class PortfolioRiskService(LoggerMixin):
             }
 
     async def optimize_allocation(
-        self, 
-        user_id: str, 
-        strategy: str = "adaptive", 
+        self,
+        user_id: str,
+        strategy: str = "adaptive",
         constraints: Dict[str, Any] = None
     ) -> Dict[str, Any]:
         """Portfolio allocation optimization with multiple strategies - NO HARDCODED ASSETS."""
@@ -1272,6 +1272,226 @@ class PortfolioRiskService(LoggerMixin):
                 "function": "optimize_allocation",
                 "request_id": request_id,
                 "timestamp": datetime.utcnow().isoformat()
+            }
+
+    async def analyze_rebalancing_strategies(
+        self,
+        user_id: str,
+        risk_profile: str = "medium",
+        rebalance_threshold: float = 0.05,
+        target_allocation: Optional[Dict[str, float]] = None
+    ) -> Dict[str, Any]:
+        """Evaluate all optimization strategies and recommend the best rebalancing plan."""
+
+        request_id = self._generate_request_id()
+        normalized_risk_profile = self._normalize_risk_profile(risk_profile)
+        self.logger.info(
+            "Analyzing multi-strategy rebalancing",
+            user_id=user_id,
+            request_id=request_id,
+            risk_profile=normalized_risk_profile,
+            rebalance_threshold=rebalance_threshold,
+        )
+
+        try:
+            portfolio = await self.portfolio_connector.get_consolidated_portfolio(user_id)
+            positions = portfolio.get("positions", [])
+            total_value = portfolio.get("total_value_usd", 0) or portfolio.get("total_value", 0)
+
+            if not positions or total_value <= 0:
+                return {
+                    "success": False,
+                    "error": "No qualifying positions found for rebalancing analysis",
+                    "function": "analyze_rebalancing_strategies",
+                    "request_id": request_id,
+                }
+
+            current_weights = self._calculate_current_weights(portfolio, total_value)
+
+            # Baseline metrics for improvement calculations
+            expected_returns, covariance_matrix = await self.optimization_engine._get_optimization_inputs(positions)
+            symbols_order = list(expected_returns.keys())
+            current_weight_vector = np.array([current_weights.get(symbol, 0.0) for symbol in symbols_order])
+            expected_return_vector = np.array([expected_returns[symbol] for symbol in symbols_order])
+            baseline_return = float(np.dot(current_weight_vector, expected_return_vector))
+            baseline_volatility = float(
+                np.sqrt(np.dot(current_weight_vector, np.dot(covariance_matrix, current_weight_vector)))
+            )
+            baseline_diversification = 1.0 - max(current_weights.values(), default=0.0)
+
+            profile_weights = self._get_risk_profile_weights(normalized_risk_profile)
+            normalized_target = self._normalize_target_allocation(target_allocation)
+
+            strategy_results: List[Dict[str, Any]] = []
+            strategy_errors: List[Dict[str, str]] = []
+
+            for strategy in OptimizationStrategy:
+                try:
+                    optimization_result = await self.optimization_engine.optimize_portfolio(
+                        portfolio,
+                        strategy=strategy,
+                        constraints={"rebalance_threshold": rebalance_threshold},
+                    )
+
+                    trades = optimization_result.suggested_trades or []
+                    total_trade_value = self._calculate_trade_volume(trades)
+                    trade_volume_pct = (total_trade_value / total_value) if total_value > 0 else 0.0
+                    execution_ready = len(trades) > 0
+
+                    weight_delta = {
+                        symbol: optimization_result.weights.get(symbol, 0.0) - current_weights.get(symbol, 0.0)
+                        for symbol in set(current_weights.keys()) | set(optimization_result.weights.keys())
+                    }
+                    max_deviation = max((abs(delta) for delta in weight_delta.values()), default=0.0)
+                    avg_deviation = (
+                        sum(abs(delta) for delta in weight_delta.values()) / len(weight_delta)
+                        if weight_delta else 0.0
+                    )
+
+                    weight_values = list(optimization_result.weights.values())
+                    diversification_score = 1.0 - (max(weight_values) if weight_values else 0.0)
+                    alignment_score = self._calculate_alignment_score(
+                        optimization_result.weights, normalized_target
+                    )
+
+                    score = (
+                        profile_weights["return"] * float(optimization_result.expected_return)
+                        + profile_weights["sharpe"] * float(optimization_result.sharpe_ratio)
+                        - profile_weights["volatility"] * float(optimization_result.expected_volatility)
+                        + profile_weights["diversification"] * diversification_score
+                        - profile_weights["cost"] * trade_volume_pct
+                        + (profile_weights["target_alignment"] * alignment_score if alignment_score is not None else 0.0)
+                    )
+
+                    needs_rebalancing = (
+                        optimization_result.rebalancing_needed
+                        or max_deviation > rebalance_threshold
+                        or trade_volume_pct > 0.01
+                        or execution_ready
+                    )
+
+                    strategy_results.append(
+                        {
+                            "strategy": strategy.value,
+                            "score": float(score),
+                            "rebalancing_needed": needs_rebalancing,
+                            "execution_ready": execution_ready,
+                            "expected_return": float(optimization_result.expected_return),
+                            "expected_volatility": float(optimization_result.expected_volatility),
+                            "sharpe_ratio": float(optimization_result.sharpe_ratio),
+                            "max_deviation": float(max_deviation),
+                            "avg_deviation": float(avg_deviation),
+                            "diversification": float(diversification_score),
+                            "total_trade_value": float(total_trade_value),
+                            "trade_volume_pct": float(trade_volume_pct),
+                            "alignment_score": float(alignment_score) if alignment_score is not None else None,
+                            "recommended_trades": trades,
+                            "target_weights": optimization_result.weights,
+                        }
+                    )
+                except Exception as strategy_error:
+                    self.logger.error(
+                        "Strategy optimization failed",
+                        error=str(strategy_error),
+                        user_id=user_id,
+                        strategy=strategy.value,
+                        request_id=request_id,
+                    )
+                    strategy_errors.append({"strategy": strategy.value, "error": str(strategy_error)})
+
+            if not strategy_results:
+                return {
+                    "success": False,
+                    "error": "All strategy evaluations failed",
+                    "function": "analyze_rebalancing_strategies",
+                    "request_id": request_id,
+                    "failed_strategies": strategy_errors,
+                }
+
+            ranked_results = sorted(strategy_results, key=lambda item: item["score"], reverse=True)
+            best_strategy = ranked_results[0]
+
+            recommended_trades = best_strategy.get("recommended_trades", [])
+            expected_return_improvement = best_strategy["expected_return"] - baseline_return
+            risk_reduction = baseline_volatility - best_strategy["expected_volatility"]
+            diversification_gain = best_strategy["diversification"] - baseline_diversification
+
+            execution_plan = self._build_execution_plan(
+                strategy_snapshot=best_strategy,
+                recommended_trades=recommended_trades,
+                total_value=total_value,
+                baseline_metrics={
+                    "baseline_return": baseline_return,
+                    "baseline_volatility": baseline_volatility,
+                    "baseline_diversification": baseline_diversification,
+                    "expected_return_improvement": expected_return_improvement,
+                    "risk_reduction": risk_reduction,
+                    "diversification_gain": diversification_gain,
+                },
+                request_id=request_id,
+                risk_profile=normalized_risk_profile,
+            )
+
+            return {
+                "success": True,
+                "function": "analyze_rebalancing_strategies",
+                "analysis_type": "multi_strategy_rebalance",
+                "request_id": request_id,
+                "risk_profile": normalized_risk_profile,
+                "needs_rebalancing": execution_plan["execution_ready"],
+                "recommended_strategy": best_strategy["strategy"],
+                "recommended_trades": recommended_trades,
+                "recommended_allocation": best_strategy["target_weights"],
+                "current_allocation": current_weights,
+                "rebalance_threshold": rebalance_threshold,
+                "strategy_rankings": [
+                    {
+                        "strategy": result["strategy"],
+                        "score": result["score"],
+                        "rebalancing_needed": result["rebalancing_needed"],
+                        "execution_ready": result["execution_ready"],
+                        "expected_return": result["expected_return"],
+                        "expected_volatility": result["expected_volatility"],
+                        "sharpe_ratio": result["sharpe_ratio"],
+                        "max_deviation_pct": result["max_deviation"] * 100,
+                        "avg_deviation_pct": result["avg_deviation"] * 100,
+                        "trade_volume_pct": result["trade_volume_pct"],
+                        "alignment_score": result["alignment_score"],
+                        "top_trades": result["recommended_trades"][:3],
+                    }
+                    for result in ranked_results
+                ],
+                "execution_plan": execution_plan,
+                "analysis_metrics": {
+                    "baseline_expected_return": baseline_return,
+                    "baseline_expected_volatility": baseline_volatility,
+                    "expected_return_improvement": expected_return_improvement,
+                    "risk_reduction": risk_reduction,
+                    "diversification_gain": diversification_gain,
+                    "trade_volume_pct": best_strategy["trade_volume_pct"],
+                    "max_deviation_pct": best_strategy["max_deviation"] * 100,
+                    "alignment_score": best_strategy["alignment_score"],
+                },
+                "total_trade_value": best_strategy["total_trade_value"],
+                "portfolio_value": total_value,
+                "timestamp": datetime.utcnow().isoformat(),
+                "failed_strategies": strategy_errors,
+            }
+
+        except Exception as e:
+            self.logger.error(
+                "Multi-strategy rebalancing analysis failed",
+                error=str(e),
+                user_id=user_id,
+                request_id=request_id,
+                exc_info=True,
+            )
+            return {
+                "success": False,
+                "error": str(e),
+                "function": "analyze_rebalancing_strategies",
+                "request_id": request_id,
+                "timestamp": datetime.utcnow().isoformat(),
             }
     
     async def complete_assessment(
@@ -1354,7 +1574,7 @@ class PortfolioRiskService(LoggerMixin):
     def _generate_request_id(self) -> str:
         """Generate unique request ID."""
         return f"PRS_{int(time.time())}_{uuid.uuid4().hex[:8]}"
-    
+
     def _make_json_serializable(self, obj: Any) -> Any:
         """Convert objects to JSON-serializable format."""
         if isinstance(obj, dict):
@@ -1370,10 +1590,239 @@ class PortfolioRiskService(LoggerMixin):
         elif hasattr(obj, 'tolist'):  # numpy array
             return obj.tolist()
         return obj
-    
+
+    def _normalize_risk_profile(self, risk_profile: Optional[str]) -> str:
+        """Normalize different risk profile labels to core categories."""
+        if not risk_profile:
+            return "medium"
+
+        normalized = risk_profile.lower()
+        if normalized in {"low", "conservative", "defensive"}:
+            return "low"
+        if normalized in {"high", "aggressive", "beast", "beast_mode"}:
+            return "high"
+        return "medium"
+
+    def _get_risk_profile_weights(self, profile: str) -> Dict[str, float]:
+        """Return scoring weights for the supplied risk profile."""
+        weight_map = {
+            "low": {
+                "return": 0.25,
+                "sharpe": 0.45,
+                "volatility": 0.60,
+                "diversification": 0.40,
+                "cost": 0.35,
+                "target_alignment": 0.30,
+            },
+            "medium": {
+                "return": 0.40,
+                "sharpe": 0.40,
+                "volatility": 0.35,
+                "diversification": 0.25,
+                "cost": 0.30,
+                "target_alignment": 0.20,
+            },
+            "high": {
+                "return": 0.55,
+                "sharpe": 0.30,
+                "volatility": 0.20,
+                "diversification": 0.15,
+                "cost": 0.15,
+                "target_alignment": 0.10,
+            },
+        }
+        return weight_map.get(profile, weight_map["medium"])
+
+    def _normalize_target_allocation(
+        self, target_allocation: Optional[Dict[str, float]]
+    ) -> Dict[str, float]:
+        """Normalize optional user target allocation into weights."""
+        if not target_allocation:
+            return {}
+
+        total = sum(value for value in target_allocation.values() if value is not None)
+        if total <= 0:
+            return {}
+
+        return {
+            symbol: float(value) / total
+            for symbol, value in target_allocation.items()
+            if value is not None
+        }
+
+    def _calculate_current_weights(
+        self, portfolio: Dict[str, Any], total_value: float
+    ) -> Dict[str, float]:
+        """Aggregate current portfolio weights by symbol."""
+
+        weights: Dict[str, float] = {}
+        if total_value <= 0:
+            return weights
+
+        for position in portfolio.get("positions", []):
+            symbol = position.get("symbol")
+            if not symbol:
+                continue
+
+            value = self._extract_position_value(position)
+            if value <= 0:
+                continue
+
+            weights[symbol] = weights.get(symbol, 0.0) + (value / total_value)
+
+        return weights
+
+    def _extract_position_value(self, position: Dict[str, Any]) -> float:
+        """Extract numeric position value from various supported keys."""
+        for key in ("value_usd", "usd_value", "value", "market_value", "current_value"):
+            value = position.get(key)
+            if value is not None:
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return 0.0
+
+    def _calculate_trade_volume(self, trades: List[Dict[str, Any]]) -> float:
+        """Aggregate absolute USD volume across suggested trades."""
+        volume = 0.0
+        for trade in trades or []:
+            raw_value = (
+                trade.get("value_change")
+                or trade.get("value_usd")
+                or trade.get("amount")
+                or trade.get("notional_usd")
+                or 0.0
+            )
+            try:
+                volume += abs(float(raw_value))
+            except (TypeError, ValueError):
+                continue
+        return volume
+
+    def _calculate_alignment_score(
+        self,
+        recommended_allocation: Dict[str, float],
+        target_allocation: Dict[str, float],
+    ) -> Optional[float]:
+        """Calculate how closely the recommendation matches target allocation."""
+        if not target_allocation:
+            return None
+
+        symbols = set(recommended_allocation.keys()) | set(target_allocation.keys())
+        total_deviation = 0.0
+        for symbol in symbols:
+            target_weight = target_allocation.get(symbol, 0.0)
+            recommended_weight = recommended_allocation.get(symbol, 0.0)
+            total_deviation += abs(target_weight - recommended_weight)
+
+        # Normalize to 0-1 range (1 is perfect alignment)
+        return max(0.0, 1.0 - (total_deviation / 2.0))
+
+    def _extract_trade_notional(self, trade: Dict[str, Any]) -> float:
+        """Extract absolute notional value for a trade recommendation."""
+        for key in (
+            "notional_usd",
+            "value_change",
+            "amount",
+            "value_usd",
+            "trade_value",
+        ):
+            value = trade.get(key)
+            if value is None:
+                continue
+            try:
+                return abs(float(value))
+            except (TypeError, ValueError):
+                continue
+        return 0.0
+
+    def _build_execution_plan(
+        self,
+        strategy_snapshot: Dict[str, Any],
+        recommended_trades: List[Dict[str, Any]],
+        total_value: float,
+        baseline_metrics: Dict[str, float],
+        request_id: str,
+        risk_profile: str,
+    ) -> Dict[str, Any]:
+        """Create an execution-ready plan for rebalancing automation."""
+
+        generated_at = datetime.utcnow()
+        steps: List[Dict[str, Any]] = []
+
+        for idx, trade in enumerate(recommended_trades, start=1):
+            notional = self._extract_trade_notional(trade)
+            reference_price = trade.get("reference_price") or trade.get("price")
+            quantity = trade.get("quantity_change") or trade.get("quantity")
+
+            if (quantity is None or quantity == 0) and reference_price not in (None, 0):
+                try:
+                    quantity = notional / float(reference_price)
+                except (TypeError, ValueError, ZeroDivisionError):
+                    quantity = None
+
+            step = {
+                "step": idx,
+                "symbol": trade.get("symbol"),
+                "action": trade.get("action"),
+                "notional_usd": round(notional, 2),
+                "target_weight": trade.get("target_weight"),
+                "current_weight": trade.get("current_weight"),
+                "weight_change": trade.get("weight_change"),
+                "exchange": trade.get("exchange"),
+                "status": "pending_execution",
+            }
+
+            if quantity is not None:
+                try:
+                    step["quantity"] = round(float(quantity), 8)
+                except (TypeError, ValueError):
+                    pass
+            if reference_price not in (None, 0):
+                try:
+                    step["reference_price"] = round(float(reference_price), 8)
+                except (TypeError, ValueError):
+                    pass
+
+            steps.append(step)
+
+        execution_ready = len(steps) > 0
+        next_review_at = generated_at + timedelta(hours=4)
+
+        return {
+            "plan_id": request_id,
+            "strategy": strategy_snapshot.get("strategy"),
+            "risk_profile": risk_profile,
+            "execution_ready": execution_ready,
+            "trade_count": len(steps),
+            "total_notional": float(strategy_snapshot.get("total_trade_value", 0.0)),
+            "expected_return_improvement": baseline_metrics.get("expected_return_improvement", 0.0),
+            "risk_reduction": baseline_metrics.get("risk_reduction", 0.0),
+            "diversification_gain": baseline_metrics.get("diversification_gain", 0.0),
+            "baseline": {
+                "portfolio_value": total_value,
+                "expected_return": baseline_metrics.get("baseline_return", 0.0),
+                "expected_volatility": baseline_metrics.get("baseline_volatility", 0.0),
+                "diversification": baseline_metrics.get("baseline_diversification", 0.0),
+            },
+            "steps": steps,
+            "generated_at": generated_at.isoformat(),
+            "next_review_at": next_review_at.isoformat(),
+            "journal_entry": {
+                "status": "pending" if execution_ready else "monitor",
+                "last_updated": generated_at.isoformat(),
+                "notes": (
+                    f"Prepare {len(steps)} trade(s) using {strategy_snapshot.get('strategy')} strategy"
+                    if execution_ready
+                    else "Portfolio is within thresholds; continue monitoring"
+                ),
+            },
+        }
+
     async def _generate_rebalancing_trades(
-        self, 
-        current_portfolio: Dict[str, Any], 
+        self,
+        current_portfolio: Dict[str, Any],
         optimal_weights: Dict[str, float]
     ) -> List[Dict[str, Any]]:
         """Generate trades needed for rebalancing to optimal weights - FIXED VERSION."""
@@ -1450,6 +1899,7 @@ class PortfolioRiskService(LoggerMixin):
                     "symbol": symbol,
                     "action": "BUY" if value_difference > 0 else "SELL",
                     "amount": abs(round(value_difference, 2)),  # FIX: Add amount field that chat system expects
+                    "notional_usd": abs(round(value_difference, 2)),
                     "target_value": round(target_value, 2),
                     "current_value": round(current_value, 2),
                     "value_change": round(value_difference, 2),

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -792,6 +792,7 @@ class UnifiedChatService(LoggerMixin):
         """
         intent = intent_analysis["intent"]
         context_data = {}
+        user_config = await self._get_user_config(user_id)
 
         # Always get basic portfolio data with error handling
         try:
@@ -940,16 +941,16 @@ class UnifiedChatService(LoggerMixin):
         elif intent == ChatIntent.REBALANCING:
             # Get rebalancing analysis
             try:
-                rebalance_data = await self._get_rebalancing_analysis(user_id)
+                rebalance_data = await self._get_rebalancing_analysis(user_id, user_config=user_config)
                 context_data["rebalance_analysis"] = rebalance_data
             except Exception as e:
                 self.logger.error("Failed to get rebalancing analysis", error=str(e), user_id=user_id)
                 context_data["rebalance_analysis"] = {"needs_rebalancing": False, "error": f"Rebalancing analysis unavailable: {str(e)}"}
-            
+
         # Add user context
-        context_data["user_config"] = await self._get_user_config(user_id)
+        context_data["user_config"] = user_config
         context_data["session_context"] = session.context
-        
+
         return context_data
     
     async def _generate_complete_response(
@@ -1170,9 +1171,9 @@ Provide a comprehensive portfolio analysis using this real data."""
         elif intent == ChatIntent.TRADE_EXECUTION:
             market = context_data.get("market_data", {})
             portfolio = context_data.get("portfolio", {})
-            
+
             return f"""User wants to execute a trade: "{message}"
-            
+
 Market Data (REAL):
 - Current Price: ${market.get('current_price', 0):,.2f}
 - 24h Change: {market.get('change_24h', 0):.2f}%
@@ -1185,6 +1186,155 @@ Portfolio:
 
 Analyze this trade request and provide recommendations. If viable, explain the 5-phase execution process."""
         
+        elif intent == ChatIntent.REBALANCING:
+            rebalance = context_data.get("rebalance_analysis", {})
+            portfolio = context_data.get("portfolio", {})
+
+            if not rebalance:
+                return f"""User asked: "{message}"
+
+REBALANCING ANALYSIS UNAVAILABLE:
+- We could not retrieve the portfolio optimization snapshot.
+- Let the user know we cannot run rebalancing right now and to try again shortly."""
+
+            if rebalance.get("error") and not rebalance.get("recommended_trades"):
+                return f"""User asked: "{message}"
+
+REBALANCING ANALYSIS ERROR:
+- Error: {rebalance.get('error')}
+- Communicate the failure, offer to rerun later, and escalate if it persists."""
+
+            strategy = rebalance.get("recommended_strategy", "unknown")
+            needs_rebalancing = bool(rebalance.get("needs_rebalancing"))
+            execution_plan = rebalance.get("execution_plan", {})
+            strategy_rankings = rebalance.get("strategy_rankings", [])
+            recommended_trades = rebalance.get("recommended_trades", [])
+            metrics = rebalance.get("analysis_metrics", {})
+            portfolio_value_raw = rebalance.get("portfolio_value") or portfolio.get("total_value", 0)
+            try:
+                portfolio_value = float(portfolio_value_raw)
+            except (TypeError, ValueError):
+                portfolio_value = 0.0
+            risk_profile = rebalance.get("user_risk_profile", "medium")
+
+            def _pct(value: Any) -> Optional[str]:
+                try:
+                    return f"{float(value):.2%}"
+                except (TypeError, ValueError):
+                    return None
+
+            plan_status = "REBALANCE REQUIRED" if needs_rebalancing else "PORTFOLIO WITHIN THRESHOLD"
+            execution_ready = execution_plan.get("execution_ready", False)
+            trade_volume_pct_raw = metrics.get("trade_volume_pct", 0.0)
+            try:
+                trade_volume_pct = float(trade_volume_pct_raw)
+            except (TypeError, ValueError):
+                trade_volume_pct = 0.0
+            total_notional_raw = execution_plan.get("total_notional")
+            try:
+                total_notional = float(total_notional_raw)
+            except (TypeError, ValueError):
+                total_notional = trade_volume_pct * portfolio_value
+
+            trade_lines: List[str] = []
+            for idx, trade in enumerate(recommended_trades[:5], 1):
+                symbol = trade.get("symbol", "?")
+                action = trade.get("action", trade.get("side", "HOLD")).upper()
+                raw_notional = (
+                    trade.get("notional_usd")
+                    or trade.get("amount")
+                    or trade.get("value_change")
+                    or trade.get("position_size_usd")
+                    or 0
+                )
+                try:
+                    notional = float(raw_notional)
+                except (TypeError, ValueError):
+                    notional = 0.0
+                weight_change = trade.get("weight_change")
+                exchange = trade.get("exchange") or "multi-exchange"
+                price = trade.get("reference_price") or trade.get("price")
+                if not isinstance(weight_change, (int, float)):
+                    try:
+                        weight_change = float(weight_change)
+                    except (TypeError, ValueError):
+                        weight_change = None
+                weight_text = f", weight Δ {weight_change:+.2%}" if isinstance(weight_change, (int, float)) else ""
+                try:
+                    price_value = float(price)
+                except (TypeError, ValueError):
+                    price_value = None
+                price_text = f" @ ${price_value:,.2f}" if price_value else ""
+                trade_lines.append(
+                    f"  {idx}. {action} {symbol} ≈ ${notional:,.2f}{price_text} on {exchange}{weight_text}"
+                )
+
+            if not trade_lines:
+                trade_lines.append("  • No trades generated — explain why the allocation stays put.")
+
+            ranking_lines: List[str] = []
+            for rank_idx, ranking in enumerate(strategy_rankings[:6], 1):
+                ranking_lines.append(
+                    "  {}. {} | score {:.3f} | trade volume {:.2%} | Sharpe {:.2f} | exp. return {:.2%}".format(
+                        rank_idx,
+                        ranking.get("strategy", "unknown"),
+                        ranking.get("score", 0.0),
+                        ranking.get("trade_volume_pct", 0.0),
+                        ranking.get("sharpe_ratio", 0.0),
+                        ranking.get("expected_return", 0.0),
+                    )
+                )
+
+            if not ranking_lines:
+                ranking_lines.append("  • Strategy ranking data unavailable")
+
+            baseline_return = _pct(metrics.get("baseline_expected_return"))
+            improvement = _pct(metrics.get("expected_return_improvement"))
+            risk_reduction = _pct(metrics.get("risk_reduction"))
+            diversification_gain = _pct(metrics.get("diversification_gain"))
+
+            instructions = [
+                f"User asked: \"{message}\"",
+                "",
+                "PORTFOLIO CONTEXT:",
+                f"- Total Value: ${portfolio_value:,.2f}",
+                f"- Risk Profile: {risk_profile}",
+                f"- Current Stance: {plan_status}",
+                "",
+                "REBALANCING SUMMARY:",
+                f"- Recommended Strategy: {strategy}",
+                f"- Execution Ready: {'YES' if execution_ready else 'NO'}",
+                f"- Trade Count: {len(recommended_trades)}",
+                f"- Total Trade Notional: ${float(total_notional or 0):,.2f}",
+            ]
+
+            if baseline_return is not None:
+                instructions.append(f"- Baseline Expected Return: {baseline_return}")
+            if improvement is not None:
+                instructions.append(f"- Expected Return Improvement: {improvement}")
+            if risk_reduction is not None:
+                instructions.append(f"- Risk Reduction (volatility): {risk_reduction}")
+            if diversification_gain is not None:
+                instructions.append(f"- Diversification Gain: {diversification_gain}")
+
+            instructions.extend([
+                "",
+                "TOP TRADE INSTRUCTIONS:",
+                *trade_lines,
+                "",
+                "STRATEGY COMPARISON (all six strategies evaluated):",
+                *ranking_lines,
+                "",
+                "GUIDANCE:",
+                "1. Explain why the recommended strategy wins compared to the others using the scores and metrics.",
+                "2. Summarize how the trades realign the portfolio and highlight any major sells/buys.",
+                "3. Respect the user's risk profile and mention how the plan adheres to it.",
+                "4. If execution_ready is false, explain the gating factor (e.g., insufficient deviation) and next review timing.",
+                "5. Conclude with clear next steps (execute now vs. monitor) and offer autonomous scheduling if applicable.",
+            ])
+
+            return "\n".join(instructions)
+
         elif intent == ChatIntent.OPPORTUNITY_DISCOVERY:
             opportunities = context_data.get("opportunities", {}).get("opportunities", [])
             strategy_performance = context_data.get("opportunities", {}).get("strategy_performance", {})
@@ -2043,43 +2193,64 @@ Provide a helpful response using the real data available. Never use placeholder 
             self.logger.error("Market risk analysis failed", error=str(e), user_id=user_id)
             return {"factors": [], "error": f"Market risk service error: {str(e)}"}
 
-    async def _get_rebalancing_analysis(self, user_id: str) -> Dict[str, Any]:
-        """Get portfolio rebalancing recommendations."""
+    async def _get_rebalancing_analysis(
+        self,
+        user_id: str,
+        user_config: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Get enterprise-grade rebalancing recommendations across all strategies."""
+
         try:
-            # Use portfolio risk service to analyze rebalancing needs
-            portfolio_data = await self._transform_portfolio_for_chat(user_id)
+            # Ensure we have the latest portfolio snapshot for chat context
+            portfolio_snapshot = await self._transform_portfolio_for_chat(user_id)
+
+            if user_config is None:
+                user_config = await self._get_user_config(user_id)
+
+            risk_preference = user_config.get("risk_tolerance", "medium")
+
+            # Run the comprehensive multi-strategy analysis
+            rebalancing_summary = await self.portfolio_risk.analyze_rebalancing_strategies(
+                user_id=user_id,
+                risk_profile=risk_preference,
+                rebalance_threshold=0.05,
+            )
+
+            if not rebalancing_summary.get("success"):
+                return {
+                    "needs_rebalancing": False,
+                    "analysis_type": "multi_strategy_rebalance",
+                    "error": rebalancing_summary.get("error", "Unable to perform rebalancing analysis"),
+                    "details": rebalancing_summary,
+                    "portfolio_snapshot": portfolio_snapshot,
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+
+            # Enrich the summary with current risk diagnostics
             risk_analysis = await self.portfolio_risk.risk_analysis(user_id)
+            if risk_analysis.get("success"):
+                rebalancing_summary["risk_snapshot"] = {
+                    "risk_metrics": risk_analysis.get("risk_metrics", {}),
+                    "risk_alerts": risk_analysis.get("risk_alerts", []),
+                    "analysis_parameters": risk_analysis.get("analysis_parameters", {}),
+                }
+            else:
+                rebalancing_summary["risk_snapshot"] = {
+                    "error": risk_analysis.get("error", "Risk analysis unavailable")
+                }
 
-            # Simple rebalancing logic - can be enhanced
-            needs_rebalancing = False
-            recommended_trades = []
+            rebalancing_summary["portfolio_snapshot"] = portfolio_snapshot
+            rebalancing_summary["user_risk_profile"] = risk_preference
 
-            if portfolio_data.get("total_value", 0) > 0:
-                positions = portfolio_data.get("positions", [])
-                total_value = portfolio_data["total_value"]
+            return rebalancing_summary
 
-                # Check if any position is over 50% of portfolio
-                for position in positions:
-                    position_pct = (position.get("value_usd", 0) / total_value) * 100
-                    if position_pct > 50:
-                        needs_rebalancing = True
-                        recommended_trades.append({
-                            "symbol": position.get("symbol"),
-                            "action": "sell",
-                            "reason": f"Position is {position_pct:.1f}% of portfolio, reduce to 30%",
-                            "target_percentage": 30
-                        })
-
-            return {
-                "needs_rebalancing": needs_rebalancing,
-                "recommended_trades": recommended_trades,
-                "risk_score": risk_analysis.get("overall_risk_score", 0),
-                "portfolio_balance": len(portfolio_data.get("positions", [])),
-                "timestamp": datetime.utcnow().isoformat()
-            }
         except Exception as e:
-            self.logger.error("Rebalancing analysis failed", error=str(e), user_id=user_id)
-            return {"needs_rebalancing": False, "error": f"Rebalancing service error: {str(e)}"}
+            self.logger.error("Rebalancing analysis failed", error=str(e), user_id=user_id, exc_info=True)
+            return {
+                "needs_rebalancing": False,
+                "analysis_type": "multi_strategy_rebalance",
+                "error": f"Rebalancing service error: {str(e)}"
+            }
 
     async def get_service_status(self) -> Dict[str, Any]:
         """Get comprehensive service status."""

--- a/tests/services/test_portfolio_risk_rebalancing.py
+++ b/tests/services/test_portfolio_risk_rebalancing.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("APP_NAME", "TestApp")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("ALLOWED_HOSTS", "*")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("ANTHROPIC_API_KEY", "test")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "test")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+os.environ.setdefault("COINMARKETCAP_API_KEY", "test")
+os.environ.setdefault("DEEPGRAM_API_KEY", "test")
+os.environ.setdefault("ANTHROPIC_MODEL", "claude-3")
+os.environ.setdefault("OPENAI_MODEL", "gpt-4")
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in os.sys.path:
+    os.sys.path.append(str(ROOT))
+
+from app.services.portfolio_risk import OptimizationStrategy
+from app.services.portfolio_risk_core import PortfolioRiskService
+
+
+@pytest.mark.asyncio
+async def test_analyze_rebalancing_strategies_returns_complete_payload():
+    service = PortfolioRiskService()
+
+    result = await service.analyze_rebalancing_strategies("integration-test-user")
+
+    assert result["success"] is True
+    assert result["analysis_type"] == "multi_strategy_rebalance"
+    assert result["needs_rebalancing"] is True
+
+    strategy_rankings = result["strategy_rankings"]
+    assert len(strategy_rankings) == len(OptimizationStrategy)
+    assert {entry["strategy"] for entry in strategy_rankings} == {
+        strategy.value for strategy in OptimizationStrategy
+    }
+
+    assert result["recommended_trades"], "Expected at least one recommended trade"
+    assert result["execution_plan"]["execution_ready"] is True
+    assert result["recommended_strategy"] in {
+        strategy.value for strategy in OptimizationStrategy
+    }
+    assert result["analysis_metrics"]["baseline_expected_return"] is not None


### PR DESCRIPTION
## Summary
- add an async regression test that exercises `PortfolioRiskService.analyze_rebalancing_strategies`
- validate the multi-strategy payload includes all strategies, trades, and execution readiness metadata

## Testing
- pytest tests/services/test_portfolio_risk_rebalancing.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f979d46c8322b93219686c481057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-strategy portfolio rebalancing with ranked strategies, execution-ready plans, and detailed trade recommendations.
  - Richer analysis outputs: expected return, risk/diversification metrics, alignment scores, and comprehensive snapshots.
  - Chat responses now include a detailed REBALANCING section, personalized by user preferences and risk profile.
  - New portfolio status view providing real-time balances, positions, P&L, and risk metrics.

- Enhancements
  - More robust trade sizing with thresholds and enriched trade details.
  - Clearer errors and structured fallbacks with explicit analysis types.

- Tests
  - Added coverage for multi-strategy rebalancing workflow and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->