### PR TITLE
Fix database session context usage

### DIFF
--- a/app/services/strategy_marketplace_service.py
+++ b/app/services/strategy_marketplace_service.py
@@ -23,7 +23,7 @@ from sqlalchemy import select, and_, desc, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
-from app.core.database import get_database
+from app.core.database import get_database_session
 from app.core.logging import LoggerMixin
 from app.core.async_session_manager import DatabaseSessionMixin
 from app.models.trading import TradingStrategy, Trade
@@ -1266,7 +1266,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
             return community_items
 
         try:
-            async with get_database() as db:
+            async with get_database_session() as db:
                 return await _load_with_session(db)
 
         except Exception as e:
@@ -1334,7 +1334,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
                 result = await db.execute(stmt)
                 recent_trades = result.scalars().all()
             else:
-                async with get_database() as db:
+                async with get_database_session() as db:
                     # Get recent trades for this strategy
                     stmt = select(Trade).where(
                         and_(
@@ -1392,7 +1392,7 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
     ) -> Dict[str, Any]:
         """Purchase access to strategy using credits."""
         try:
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Get user's credit account
                 credit_stmt = select(CreditAccount).where(CreditAccount.user_id == user_id)
                 credit_result = await db.execute(credit_stmt)
@@ -1616,11 +1616,11 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
 
         # ADMIN BYPASS: For admin users, check if we should use fast database path
         try:
-            from app.core.database import get_database
+            from app.core.database import get_database_session
             from app.models.user import User, UserRole
             from sqlalchemy import select
 
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Check if this is an admin user (convert string UUID to proper UUID)
                 import uuid
                 try:

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 
 from app.core.config import get_settings
 from app.core.logging import LoggerMixin
-from app.core.database import AsyncSessionLocal
+from app.core.database import AsyncSessionLocal, get_database_session
 from app.core.redis import get_redis_client
 
 # Import the new ChatAI service for conversations
@@ -590,12 +590,11 @@ class UnifiedChatService(LoggerMixin):
         Uses the same credit lookup logic as the API endpoint.
         """
         try:
-            from app.core.database import get_database
             from app.models.credit import CreditAccount
             from sqlalchemy import select
             import uuid
 
-            async with get_database() as db:
+            async with get_database_session() as db:
                 # Try multiple lookup methods to find existing account
                 credit_account = None
 
@@ -713,11 +712,10 @@ class UnifiedChatService(LoggerMixin):
             # Use EXACT same code path as working trading API endpoint
             import asyncio
             from app.api.v1.endpoints.exchanges import get_user_portfolio_from_exchanges
-            from app.core.database import get_database
 
             # Fix: Apply timeout at the correct level to avoid async context conflicts
             async def _fetch_portfolio():
-                async with get_database() as db:
+                async with get_database_session() as db:
                     return await get_user_portfolio_from_exchanges(str(user_id), db)
 
             portfolio_data = await asyncio.wait_for(_fetch_portfolio(), timeout=15.0)

--- a/debug_credit_duplication.py
+++ b/debug_credit_duplication.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'app'))
 async def debug_credit_accounts():
     print("=== INVESTIGATING CREDIT ACCOUNT DUPLICATION ===")
 
-    from app.core.database import get_database
+    from app.core.database import get_database_session
     from app.models.credit import CreditAccount
     from app.models.user import User
     from sqlalchemy import select, text
@@ -23,7 +23,7 @@ async def debug_credit_accounts():
     user_id_str = "7a1ee8cd-bfc9-4e4e-85b2-69c8e91054af"
     user_uuid = uuid.UUID(user_id_str)
 
-    async with get_database() as db:
+    async with get_database_session() as db:
         print(f"1. Searching for ALL credit accounts for user_id: {user_id_str}")
 
         # Search by UUID

--- a/debug_exchange_accounts.py
+++ b/debug_exchange_accounts.py
@@ -12,13 +12,13 @@ from uuid import UUID
 sys.path.append(os.path.join(os.path.dirname(__file__), 'app'))
 
 async def debug_exchanges():
-    from app.core.database import get_database
+    from app.core.database import get_database_session
     from app.models.exchange import ExchangeAccount, ExchangeApiKey, ExchangeBalance, ApiKeyStatus, ExchangeStatus
     from sqlalchemy import select, and_, or_
 
     user_id = '7a1ee8cd-bfc9-4e4e-85b2-69c8e91054af'
 
-    async with get_database() as db:
+    async with get_database_session() as db:
         print(f"\n=== DEBUGGING EXCHANGE ACCOUNTS FOR USER {user_id} ===\n")
 
         # 1. Check all exchange accounts for this user

--- a/debug_orchestrator_credit.py
+++ b/debug_orchestrator_credit.py
@@ -21,14 +21,14 @@ async def debug_orchestrator_credit():
 
     try:
         # Test the exact same logic as orchestrator
-        from app.core.database import get_database
+        from app.core.database import get_database_session
         from app.api.v1.endpoints.credits import get_or_create_credit_account
 
         # Convert string user_id to UUID (same as credit API)
         user_uuid = uuid.UUID(user_id_str)
         print(f"Converted to UUID: {user_uuid} (type: {type(user_uuid)})")
 
-        async with get_database() as db:
+        async with get_database_session() as db:
             print("Calling get_or_create_credit_account...")
             # Use the EXACT same function as credit API
             credit_account = await get_or_create_credit_account(user_uuid, db)

--- a/test_direct_portfolio.py
+++ b/test_direct_portfolio.py
@@ -12,13 +12,13 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'app'))
 
 async def test_portfolio():
     from app.api.v1.endpoints.exchanges import get_user_portfolio_from_exchanges
-    from app.core.database import get_database
+    from app.core.database import get_database_session
 
     user_id = '7a1ee8cd-bfc9-4e4e-85b2-69c8e91054af'
 
     print(f"Testing portfolio for user: {user_id}")
 
-    async with get_database() as db:
+    async with get_database_session() as db:
         result = await get_user_portfolio_from_exchanges(user_id, db)
         print(f'Success: {result.get("success")}')
         print(f'Total value: ${result.get("total_value_usd", 0):,.2f}')


### PR DESCRIPTION
## Summary
- replace direct use of `get_database()` as an async context manager with the dedicated `get_database_session()` helper across chat and strategy services
- update supporting debug and test scripts to rely on the same session manager to prevent runtime `async_generator` context errors

## Testing
- python -m compileall app/services/unified_chat_service.py app/services/strategy_marketplace_service.py debug_exchange_accounts.py debug_credit_duplication.py debug_orchestrator_credit.py test_direct_portfolio.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d0c09e248322afa8fa4fbf51cacc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database session management across services for improved stability and consistency.
* **Chores**
  * Updated internal debug utilities to align with the new session handling.
* **Tests**
  * Adjusted tests and enhanced logging to aid troubleshooting and visibility into balances and errors.
* **Notes**
  * No user-facing changes; functionality and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->