### PR TITLE
Fix admin strategy approval filters for published strategies

### DIFF
--- a/frontend/src/components/admin/StrategyApproval.tsx
+++ b/frontend/src/components/admin/StrategyApproval.tsx
@@ -80,7 +80,7 @@ interface PendingStrategy {
   profit_share_percentage?: number;
   
   // Status and Timeline
-  status: 'submitted' | 'under_review' | 'changes_requested' | 'approved' | 'rejected';
+  status: 'submitted' | 'under_review' | 'changes_requested' | 'approved' | 'rejected' | 'published';
   submitted_at: string;
   assigned_reviewer?: string;
   review_started_at?: string;
@@ -167,8 +167,9 @@ const StrategyApproval: React.FC = () => {
   const { data: strategies, isLoading: strategiesLoading, error: strategiesError } = useQuery({
     queryKey: ['admin-pending-strategies', selectedStatus],
     queryFn: async () => {
+      const params = selectedStatus !== 'all' ? { status_filter: selectedStatus } : undefined;
       const response = await apiClient.get('/admin/strategies/pending', {
-        params: { status: selectedStatus !== 'all' ? selectedStatus : undefined }
+        params
       });
       return response.data.strategies as PendingStrategy[];
     },
@@ -224,7 +225,9 @@ const StrategyApproval: React.FC = () => {
       case 'submitted': return 'bg-blue-500';
       case 'under_review': return 'bg-yellow-500';
       case 'changes_requested': return 'bg-orange-500';
-      case 'approved': return 'bg-green-500';
+      case 'approved':
+      case 'published':
+        return 'bg-green-500';
       case 'rejected': return 'bg-red-500';
       default: return 'bg-gray-500';
     }
@@ -235,10 +238,19 @@ const StrategyApproval: React.FC = () => {
       case 'submitted': return <Upload className="h-4 w-4" />;
       case 'under_review': return <Clock className="h-4 w-4" />;
       case 'changes_requested': return <Edit className="h-4 w-4" />;
-      case 'approved': return <CheckCircle className="h-4 w-4" />;
+      case 'approved':
+      case 'published':
+        return <CheckCircle className="h-4 w-4" />;
       case 'rejected': return <XCircle className="h-4 w-4" />;
       default: return <FileText className="h-4 w-4" />;
     }
+  };
+
+  const getStatusLabel = (status: PendingStrategy['status']) => {
+    if (status === 'published') {
+      return 'Published';
+    }
+    return status.replace('_', ' ').toUpperCase();
   };
 
   const getPriorityColor = (score: number) => {
@@ -413,6 +425,7 @@ const StrategyApproval: React.FC = () => {
                 <SelectItem value="under_review">Under Review</SelectItem>
                 <SelectItem value="changes_requested">Changes Requested</SelectItem>
                 <SelectItem value="approved">Approved</SelectItem>
+                <SelectItem value="published">Published</SelectItem>
                 <SelectItem value="rejected">Rejected</SelectItem>
                 <SelectItem value="all">All Strategies</SelectItem>
               </SelectContent>
@@ -461,7 +474,7 @@ const StrategyApproval: React.FC = () => {
                         {getStatusIcon(strategy.status)}
                       </div>
                       <Badge className={getStatusColor(strategy.status) + ' text-white'}>
-                        {strategy.status.replace('_', ' ').toUpperCase()}
+                        {getStatusLabel(strategy.status)}
                       </Badge>
                     </div>
                     
@@ -587,10 +600,19 @@ const StrategyApproval: React.FC = () => {
                           Waiting for publisher response
                         </Badge>
                       ) : (
-                        <Badge variant="outline" className={
-                          strategy.status === 'approved' ? 'text-green-600' : 'text-red-600'
-                        }>
-                          {strategy.status === 'approved' ? 'Approved' : 'Rejected'}
+                        <Badge
+                          variant="outline"
+                          className={
+                            strategy.status === 'approved' || strategy.status === 'published'
+                              ? 'text-green-600'
+                              : 'text-red-600'
+                          }
+                        >
+                          {strategy.status === 'published'
+                            ? 'Published'
+                            : strategy.status === 'approved'
+                              ? 'Approved'
+                              : 'Rejected'}
                         </Badge>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- add support for the published status in the admin strategy approval and debug views, including display labels and filters
- align the pending strategy request with the backend by sending the expected status_filter query parameter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d39c8ccc83229d675c330b15ad21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “Published” status for strategies, now selectable in the status filter.
  - Updated UI to treat “Published” like “Approved,” with shared icons, colors, and badges.
  - Improved status display with human-friendly labels across lists, badges, and detail views.

- Refactor
  - Centralized status-to-label formatting via a helper for consistent text and styling.
  - Streamlined status filtering by sending a filter only when a specific status is selected (omitted for “All”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->