### PR TITLE
Fix slow query logging thresholds

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -164,15 +164,15 @@ def receive_after_cursor_execute(conn, cursor, statement, parameters, context, e
     logger = structlog.get_logger()
     
     # ENTERPRISE: Log all slow queries regardless of environment
-    if total > 0.2:  # ENTERPRISE STANDARD: Warn on queries >200ms
-        logger.warning(
-            "Slow database query",
+    if total > 0.5:  # ENTERPRISE: Error on queries >500ms
+        logger.error(
+            "Very slow database query",
             duration=total,
             statement=statement[:200] + "..." if len(statement) > 200 else statement
         )
-    elif total > 0.5:  # ENTERPRISE: Error on queries >500ms
-        logger.error(
-            "Very slow database query",
+    elif total > 0.2:  # ENTERPRISE STANDARD: Warn on queries >200ms
+        logger.warning(
+            "Slow database query",
             duration=total,
             statement=statement[:200] + "..." if len(statement) > 200 else statement
         )


### PR DESCRIPTION
## Summary
- flip the slow-query logging thresholds so very slow queries trigger the error log branch
- keep the warning path as the fallback for moderately slow queries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d60db0e48322a11ce5e9d531f429