### PR TITLE
Allow optional session IDs when creating chat sessions

### DIFF
--- a/app/services/ai_chat_engine.py
+++ b/app/services/ai_chat_engine.py
@@ -240,14 +240,10 @@ class EnhancedAIChatEngine(LoggerMixin):
                     )
                     return last_session["session_id"]
             
-            # Generate proper UUID for new session
-            session_id = str(uuid.uuid4())
-            
-            # Create new session with the UUID
+            # Create new session
             created_session_id = await self.memory.create_session(
                 user_id=user_id,
                 session_type=session_type,
-                session_id=session_id,  # Pass the UUID to ensure proper format
                 context={
                     "preferences": {},
                     "active_strategies": [],
@@ -255,9 +251,11 @@ class EnhancedAIChatEngine(LoggerMixin):
                     "created_via": "chat_interface"
                 }
             )
-            
-            # Use the created session ID (should be the same UUID we passed)
-            session_id = created_session_id if created_session_id else session_id
+
+            if not created_session_id:
+                raise ValueError("Chat session was not created successfully")
+
+            session_id = created_session_id
             
             # Add welcome message
             await self.memory.save_message(


### PR DESCRIPTION
## Summary
- allow the chat memory service to accept an optional session identifier when creating a session
- rely on the memory service to provide the new session id inside the enhanced AI chat engine and validate the result

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d68f260883228018abaf2f23db5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Persistent chat sessions now auto-populate context (interface, conversation mode, session type) with trading mode derived from your settings.
- Bug Fixes
  - Eliminates session ID mismatches by using server-assigned IDs and clearly failing when creation is unsuccessful.
- Refactor
  - Streamlined session initialization and loading of saved context for more consistent timestamps and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->