### PR TITLE
Normalize portfolio improvement parsing

### DIFF
--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -1306,29 +1306,34 @@ class UserOpportunityDiscoveryService(LoggerMixin):
                 
                 # Process recommendations from all strategies
                 if rebalancing_recommendations:
+                    def _normalize_improvement(value: Any) -> float:
+                        """Convert raw improvement values to a 0-1 range."""
+                        if value is None:
+                            return 0.0
+
+                        try:
+                            is_percent = False
+
+                            if isinstance(value, str):
+                                cleaned_value = value.strip()
+                                if cleaned_value.endswith("%"):
+                                    cleaned_value = cleaned_value[:-1]
+                                    is_percent = True
+                                parsed_value = float(cleaned_value)
+                            else:
+                                parsed_value = float(value)
+
+                            if is_percent or parsed_value > 1.0:
+                                parsed_value /= 100.0
+
+                            return max(0.0, min(parsed_value, 1.0))
+                        except (TypeError, ValueError):
+                            return 0.0
+
                     for rebal in rebalancing_recommendations:
                         # Include all recommendations, not filtered by improvement
                         improvement_raw = rebal.get("improvement_potential", 0)
-
-                        improvement_normalized = 0.0
-                        if improvement_raw is not None:
-                            try:
-                                is_percent = False
-                                if isinstance(improvement_raw, str):
-                                    improvement_str = improvement_raw.strip()
-                                    if improvement_str.endswith("%"):
-                                        improvement_str = improvement_str[:-1]
-                                        is_percent = True
-                                    improvement_value = float(improvement_str)
-                                else:
-                                    improvement_value = float(improvement_raw)
-
-                                if is_percent or improvement_value > 1.0:
-                                    improvement_value /= 100.0
-
-                                improvement_normalized = max(0.0, min(improvement_value, 1.0))
-                            except (TypeError, ValueError):
-                                improvement_normalized = 0.0
+                        improvement_normalized = _normalize_improvement(improvement_raw)
 
                         strategy_name = rebal.get("strategy", "UNKNOWN")
 

--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -1313,13 +1313,20 @@ class UserOpportunityDiscoveryService(LoggerMixin):
                         improvement_normalized = 0.0
                         if improvement_raw is not None:
                             try:
+                                is_percent = False
                                 if isinstance(improvement_raw, str):
                                     improvement_str = improvement_raw.strip()
                                     if improvement_str.endswith("%"):
                                         improvement_str = improvement_str[:-1]
-                                    improvement_normalized = float(improvement_str)
+                                        is_percent = True
+                                    improvement_value = float(improvement_str)
                                 else:
-                                    improvement_normalized = float(improvement_raw)
+                                    improvement_value = float(improvement_raw)
+
+                                if is_percent or improvement_value > 1.0:
+                                    improvement_value /= 100.0
+
+                                improvement_normalized = max(0.0, min(improvement_value, 1.0))
                             except (TypeError, ValueError):
                                 improvement_normalized = 0.0
 
@@ -1341,7 +1348,7 @@ class UserOpportunityDiscoveryService(LoggerMixin):
                             metadata={
                                 "rebalance_action": rebal.get("action", ""),
                                 "strategy_used": strategy_name,
-                                "improvement_potential": improvement_normalized,
+                                "improvement_potential": improvement_raw,
                                 "normalized_improvement": improvement_normalized,
                                 "risk_reduction": rebal.get("risk_reduction", 0),
                                 "amount": rebal.get("amount", 0),


### PR DESCRIPTION
## Summary
- parse portfolio optimization improvement values robustly, including percentage strings
- reuse the normalized improvement value across metadata and profit calculations
- expose the normalized improvement in opportunity metadata for downstream consumers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d820c9b0b48322823abaa58d373ac8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a normalized_improvement field in opportunity metadata for consistent reporting.
- Bug Fixes
  - Standardized interpretation of improvement inputs (including percentage strings and missing values), ensuring reliable profit potential (USD) calculations.
  - Replaced raw improvement values with normalized figures across calculations and metadata to prevent errors and inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->