### PR TITLE
Integrate credit ledger accounting and add tests

### DIFF
--- a/CREDIT_SYSTEM_AUDIT_SUMMARY.md
+++ b/CREDIT_SYSTEM_AUDIT_SUMMARY.md
@@ -1,0 +1,20 @@
+# Credit System & Platform Audit Summary
+
+This document captures the key findings from the automated review of the CryptoUniverse platform and deployed Render instance.
+
+## Observations
+
+1. The FastAPI credit balance endpoint returns balances, but profit-potential and transaction-history endpoints surface inconsistencies: profit potential returns `0` despite a non-zero balance, and transaction history fails because the database schema is missing the `provider` column expected by the ORM model.
+2. Several backend services (credit purchase allocation, profit-sharing, Telegram bot) expect `CreditAccount.total_purchased_credits`/`total_used_credits`, yet the model defines only `total_credits` and `used_credits`, leading to runtime errors and inconsistent metrics.
+3. The unified chat service enforces a apparently static 10-credit requirement but never deducts credits for chat-initiated operations, so credit usage for chats/signals is not implemented.
+4. The frontend credit dashboard relies on static subscription/credit pack data and assumes backend fields (`total_purchased_credits`, `total_used_credits`) that are unavailable, so the UI cannot reflect real credit consumption.
+5. Database migrations (e.g., provider column) appear out of sync with the deployed database, indicating that migration execution must be revisited before relying on the credit transaction ledger.
+
+## Recommendations
+
+- Align the `CreditAccount` schema and migrations with the fields that the services and frontend require (e.g., `total_purchased_credits`, `total_used_credits`).
+- Rebuild the profit-potential calculations to derive values from actual credit purchases/usage, and ensure migrations add the missing columns used in those calculations.
+- Extend the unified chat workflow to log and deduct credits for chargeable interactions, and integrate that logic with both API and Telegram flows.
+- Replace static frontend credit center data with live responses from `/credits/balance`, `/credits/purchase-options`, and `/credits/transaction-history` once backend responses are accurate.
+- Audit and replay Alembic migrations on the production database so that ORM expectations match the persisted schema, preventing 500-level errors on credit APIs.
+

--- a/alembic/versions/008_add_credit_account_lifecycle_columns.py
+++ b/alembic/versions/008_add_credit_account_lifecycle_columns.py
@@ -1,0 +1,62 @@
+"""Add lifetime credit tracking columns
+
+Revision ID: 008_add_credit_account_lifecycle_columns
+Revises: 007_rename_market_data_to_legacy
+Create Date: 2025-02-16 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+
+revision = "008_add_credit_account_lifecycle_columns"
+down_revision = "007_rename_market_data_to_legacy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add lifetime tracking columns and backfill existing data."""
+
+    with op.batch_alter_table("credit_accounts") as batch_op:
+        batch_op.add_column(sa.Column("total_purchased_credits", sa.Integer(), nullable=False, server_default="0"))
+        batch_op.add_column(sa.Column("total_used_credits", sa.Integer(), nullable=False, server_default="0"))
+        batch_op.add_column(sa.Column("last_usage_at", sa.DateTime(), nullable=True))
+
+    bind = op.get_bind()
+
+    # Align new counters with existing balances
+    bind.execute(
+        text(
+            """
+            UPDATE credit_accounts
+            SET total_purchased_credits = COALESCE(total_credits, 0),
+                total_used_credits = COALESCE(used_credits, 0)
+            """
+        )
+    )
+
+    # Ensure profit potential limits remain consistent with new totals
+    bind.execute(
+        text(
+            """
+            UPDATE credit_accounts
+            SET total_profit_potential_usd = COALESCE(total_credits, 0) * 4,
+                current_profit_limit_usd = GREATEST(COALESCE(total_credits, 0), COALESCE(available_credits, 0)) * 4
+            """
+        )
+    )
+
+    with op.batch_alter_table("credit_accounts") as batch_op:
+        batch_op.alter_column("total_purchased_credits", server_default=None)
+        batch_op.alter_column("total_used_credits", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove lifetime tracking columns."""
+
+    with op.batch_alter_table("credit_accounts") as batch_op:
+        batch_op.drop_column("last_usage_at")
+        batch_op.drop_column("total_used_credits")
+        batch_op.drop_column("total_purchased_credits")

--- a/alembic/versions/008_add_credit_account_lifecycle_columns.py
+++ b/alembic/versions/008_add_credit_account_lifecycle_columns.py
@@ -43,7 +43,13 @@ def upgrade() -> None:
             """
             UPDATE credit_accounts
             SET total_profit_potential_usd = COALESCE(total_credits, 0) * 4,
-                current_profit_limit_usd = GREATEST(COALESCE(total_credits, 0), COALESCE(available_credits, 0)) * 4
+                current_profit_limit_usd = (
+                    CASE
+                        WHEN COALESCE(total_credits, 0) >= COALESCE(available_credits, 0)
+                            THEN COALESCE(total_credits, 0)
+                        ELSE COALESCE(available_credits, 0)
+                    END
+                ) * 4
             """
         )
     )

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -1223,11 +1223,11 @@ async def manage_user(
                         transaction_type=CreditTransactionType.ADJUSTMENT,
                         metadata=metadata,
                     )
-                except InsufficientCreditsError:
+                except InsufficientCreditsError as e:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="Cannot reduce credits below zero",
-                    )
+                    ) from e
 
             action_taken = f"Credits set to {target_balance}"
         

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -1222,7 +1222,6 @@ async def manage_user(
                         source="admin_console",
                         transaction_type=CreditTransactionType.ADJUSTMENT,
                         metadata=metadata,
-                        track_usage=False,
                     )
                 except InsufficientCreditsError:
                     raise HTTPException(

--- a/app/api/v1/endpoints/trading.py
+++ b/app/api/v1/endpoints/trading.py
@@ -24,13 +24,14 @@ from app.api.v1.endpoints.auth import get_current_user, require_role
 from app.models.user import User, UserRole
 from app.models.trading import Trade, Position, Order, TradingStrategy
 from app.models.exchange import ExchangeAccount
-from app.models.credit import CreditAccount, CreditTransaction, CreditTransactionType
+from app.models.credit import CreditAccount, CreditTransactionType
 from app.services.trade_execution import TradeExecutionService
 from app.services.master_controller import MasterSystemController
 from app.services.portfolio_risk_core import PortfolioRiskServiceExtended
 from app.services.market_analysis_core import market_analysis_service
 from app.services.rate_limit import rate_limiter
 from app.services.websocket import manager
+from app.services.credit_ledger import credit_ledger, InsufficientCreditsError
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -235,22 +236,28 @@ async def execute_manual_trade(
         # Deduct credits for real trades
         if not simulation_mode:
             credit_cost = calculate_credit_cost(request.amount, request.symbol)
-            if credit_account.available_credits >= credit_cost:
-                credit_account.available_credits -= credit_cost
-                credit_account.total_used_credits += credit_cost
-                
-                # Record transaction
-                credit_tx = CreditTransaction(
-                    account_id=credit_account.id,
-                    amount=-credit_cost,
+            try:
+                await credit_ledger.consume_credits(
+                    db,
+                    credit_account,
+                    credits=credit_cost,
+                    description=f"Trade execution: {request.action} {request.symbol}",
+                    source="trading_api",
                     transaction_type=CreditTransactionType.USAGE,
-                    description=f"Trade: {request.action} {request.symbol}",
-                    balance_before=credit_account.available_credits + credit_cost,
-                    balance_after=credit_account.available_credits,
-                    source="api"
+                    metadata={
+                        "symbol": request.symbol,
+                        "amount": float(request.amount),
+                        "order_type": request.order_type,
+                        "exchange": request.exchange,
+                    },
                 )
-                db.add(credit_tx)
                 await db.commit()
+            except InsufficientCreditsError:
+                await db.rollback()
+                raise HTTPException(
+                    status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                    detail="Insufficient credits for trading",
+                )
         
         trade_result = result.get("trade_result", {}) or result.get("simulation_result", {})
         

--- a/app/services/credit_ledger.py
+++ b/app/services/credit_ledger.py
@@ -91,7 +91,15 @@ class CreditLedger:
         await db.flush()
 
         if initial_credits > 0:
-            account.register_credit_increase(initial_credits)
+            await self.add_credits(
+                db,
+                account,
+                credits=initial_credits,
+                transaction_type=CreditTransactionType.BONUS,
+                description="Initial account credits",
+                source="system",
+                track_lifetime=False,
+            )
             await db.flush()
 
         return account

--- a/app/services/credit_ledger.py
+++ b/app/services/credit_ledger.py
@@ -1,0 +1,260 @@
+"""Centralized credit ledger management."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, Optional, Union
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.credit import (
+    CreditAccount,
+    CreditStatus,
+    CreditTransaction,
+    CreditTransactionType,
+)
+
+
+class CreditLedgerError(Exception):
+    """Base exception for credit ledger operations."""
+
+
+class InsufficientCreditsError(CreditLedgerError):
+    """Raised when a debit exceeds the available credit balance."""
+
+
+def _coerce_decimal(value: Optional[Union[Decimal, float, str]]) -> Optional[Decimal]:
+    """Convert numeric input to Decimal while preserving None."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, Decimal):
+        return value
+
+    try:
+        return Decimal(str(value))
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"Unable to convert value '{value}' to Decimal") from exc
+
+
+class CreditLedger:
+    """Enterprise-grade credit ledger with consistent accounting rules."""
+
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger(__name__)
+
+    @staticmethod
+    def _normalize_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not metadata:
+            return {}
+        return {str(key): value for key, value in metadata.items() if value is not None}
+
+    async def get_account(
+        self,
+        db: AsyncSession,
+        user_id: Union[str, uuid.UUID],
+        *,
+        for_update: bool = False,
+        create_if_missing: bool = False,
+        initial_credits: int = 0,
+    ) -> Optional[CreditAccount]:
+        """Fetch (and optionally create) a credit account."""
+
+        stmt = select(CreditAccount).where(CreditAccount.user_id == user_id)
+        if for_update:
+            stmt = stmt.with_for_update()
+
+        result = await db.execute(stmt)
+        account = result.scalar_one_or_none()
+
+        if account or not create_if_missing:
+            return account
+
+        account = CreditAccount(user_id=user_id)
+        db.add(account)
+        await db.flush()
+
+        if initial_credits > 0:
+            account.register_credit_increase(initial_credits)
+            await db.flush()
+
+        return account
+
+    async def add_credits(
+        self,
+        db: AsyncSession,
+        account: CreditAccount,
+        *,
+        credits: int,
+        transaction_type: CreditTransactionType,
+        description: str,
+        source: str,
+        provider: Optional[str] = None,
+        reference_id: Optional[str] = None,
+        usd_value: Optional[Union[Decimal, float, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        track_lifetime: bool = True,
+    ) -> CreditTransaction:
+        """Increase available credits and record the transaction."""
+
+        if credits <= 0:
+            raise ValueError("Credits to add must be positive")
+
+        timestamp = datetime.utcnow()
+        balance_before, balance_after = account.register_credit_increase(
+            credits,
+            track_lifetime=track_lifetime,
+            timestamp=timestamp,
+        )
+
+        transaction = CreditTransaction(
+            account_id=account.id,
+            amount=credits,
+            transaction_type=transaction_type,
+            description=description,
+            balance_before=balance_before,
+            balance_after=balance_after,
+            source=source,
+            provider=provider,
+            reference_id=reference_id,
+            usd_value=_coerce_decimal(usd_value),
+            meta_data=self._normalize_metadata(metadata),
+            status=CreditStatus.ACTIVE,
+            created_at=timestamp,
+            processed_at=timestamp,
+        )
+
+        db.add(transaction)
+        await db.flush()
+
+        self.logger.debug(
+            "Credits added",
+            account_id=str(account.id),
+            credits=credits,
+            transaction_type=transaction_type.value,
+            source=source,
+        )
+
+        return transaction
+
+    async def consume_credits(
+        self,
+        db: AsyncSession,
+        account: CreditAccount,
+        *,
+        credits: int,
+        description: str,
+        source: str,
+        transaction_type: CreditTransactionType = CreditTransactionType.USAGE,
+        metadata: Optional[Dict[str, Any]] = None,
+        trade_id: Optional[uuid.UUID] = None,
+        profit_amount: Optional[Union[Decimal, float, str]] = None,
+        track_usage: bool = True,
+    ) -> CreditTransaction:
+        """Deduct credits and record the usage transaction."""
+
+        if credits <= 0:
+            raise ValueError("Credits to deduct must be positive")
+
+        available_balance = int(account.available_credits or 0)
+        if credits > available_balance:
+            raise InsufficientCreditsError(
+                f"Insufficient credits: required={credits}, available={available_balance}"
+            )
+
+        timestamp = datetime.utcnow()
+        balance_before, balance_after = account.register_credit_usage(
+            credits,
+            track_usage=track_usage,
+            timestamp=timestamp,
+        )
+
+        transaction = CreditTransaction(
+            account_id=account.id,
+            amount=-credits,
+            transaction_type=transaction_type,
+            description=description,
+            balance_before=balance_before,
+            balance_after=balance_after,
+            source=source,
+            trade_id=trade_id,
+            profit_amount_usd=_coerce_decimal(profit_amount),
+            meta_data=self._normalize_metadata(metadata),
+            status=CreditStatus.ACTIVE,
+            created_at=timestamp,
+            processed_at=timestamp,
+        )
+
+        db.add(transaction)
+        await db.flush()
+
+        self.logger.debug(
+            "Credits consumed",
+            account_id=str(account.id),
+            credits=credits,
+            transaction_type=transaction_type.value,
+            source=source,
+        )
+
+        return transaction
+
+    async def refund_credits(
+        self,
+        db: AsyncSession,
+        account: CreditAccount,
+        *,
+        credits: int,
+        description: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        reference_transaction_id: Optional[uuid.UUID] = None,
+    ) -> CreditTransaction:
+        """Refund credits that were previously consumed."""
+
+        if credits <= 0:
+            raise ValueError("Credits to refund must be positive")
+
+        timestamp = datetime.utcnow()
+        balance_before, balance_after = account.reverse_credit_usage(
+            credits,
+            adjust_usage_totals=True,
+            timestamp=timestamp,
+        )
+
+        refund_metadata = self._normalize_metadata(metadata)
+        if reference_transaction_id:
+            refund_metadata.setdefault("refund_for", str(reference_transaction_id))
+
+        transaction = CreditTransaction(
+            account_id=account.id,
+            amount=credits,
+            transaction_type=CreditTransactionType.REFUND,
+            description=description,
+            balance_before=balance_before,
+            balance_after=balance_after,
+            source=source,
+            meta_data=refund_metadata,
+            status=CreditStatus.ACTIVE,
+            created_at=timestamp,
+            processed_at=timestamp,
+        )
+
+        db.add(transaction)
+        await db.flush()
+
+        self.logger.debug(
+            "Credits refunded",
+            account_id=str(account.id),
+            credits=credits,
+            source=source,
+        )
+
+        return transaction
+
+
+credit_ledger = CreditLedger()

--- a/app/services/crypto_payment_service.py
+++ b/app/services/crypto_payment_service.py
@@ -533,12 +533,13 @@ class CryptoPaymentService(LoggerMixin):
                     transaction_type=CreditTransactionType.PURCHASE,
                     description=f"Crypto payment allocation ({payment_id})",
                     source="crypto_payment",
+                    reference_id=payment_id,
                     metadata={"payment_id": payment_id},
                 )
 
-                # Update transaction status - use stripe_payment_intent_id field instead
+                # Update transaction status using shared reference_id for reconciliation
                 tx_stmt = select(CreditTransaction).where(
-                    CreditTransaction.stripe_payment_intent_id == payment_id
+                    CreditTransaction.reference_id == payment_id
                 )
                 tx_result = await db.execute(tx_stmt)
                 transaction = tx_result.scalar_one_or_none()
@@ -552,8 +553,8 @@ class CryptoPaymentService(LoggerMixin):
                     "Credits allocated successfully",
                     user_id=user_id,
                     credits=credit_amount,
-                        payment_id=payment_id
-                    )
+                    payment_id=payment_id,
+                )
         
         except Exception as e:
             self.logger.error("Credit allocation failed", error=str(e))

--- a/app/services/profit_sharing_service.py
+++ b/app/services/profit_sharing_service.py
@@ -585,6 +585,7 @@ class ProfitSharingService(LoggerMixin):
                     metadata={
                         "welcome_profit_potential": welcome_profit_potential,
                     },
+                    track_lifetime=False,
                 )
 
                 await db.commit()

--- a/app/services/profit_sharing_service.py
+++ b/app/services/profit_sharing_service.py
@@ -349,6 +349,8 @@ class ProfitSharingService(LoggerMixin):
                     transaction_type=CreditTransactionType.PURCHASE,
                     description=f"Profit sharing purchase: Paid ${platform_fee:.2f}, earned {credits_earned} credits",
                     source="profit_sharing",
+                    provider=payment_method,
+                    reference_id=payment_result.get("payment_id"),
                     usd_value=platform_fee,
                     metadata={
                         "payment_method": payment_method,

--- a/app/services/profit_sharing_service.py
+++ b/app/services/profit_sharing_service.py
@@ -21,8 +21,9 @@ from app.core.database import get_database
 from app.core.logging import LoggerMixin
 from app.models.user import User
 from app.models.trading import Trade, TradingStrategy, TradeStatus
-from app.models.credit import CreditAccount, CreditTransaction, CreditTransactionType
+from app.models.credit import CreditAccount, CreditTransactionType
 from app.models.subscription import Subscription
+from app.services.credit_ledger import credit_ledger
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -341,22 +342,20 @@ class ProfitSharingService(LoggerMixin):
                         "error": f"Payment processing failed: {payment_result.get('error')}"
                     }
                 
-                # Add credits to user account
-                credit_account.available_credits += credits_earned
-                credit_account.total_purchased_credits += credits_earned
-                
-                # Record transaction
-                transaction = CreditTransaction(
-                    account_id=credit_account.id,
-                    amount=credits_earned,
+                await credit_ledger.add_credits(
+                    db,
+                    credit_account,
+                    credits=credits_earned,
                     transaction_type=CreditTransactionType.PURCHASE,
                     description=f"Profit sharing purchase: Paid ${platform_fee:.2f}, earned {credits_earned} credits",
-                    balance_before=credit_account.available_credits - credits_earned,
-                    balance_after=credit_account.available_credits,
-                    source="system"
+                    source="profit_sharing",
+                    usd_value=platform_fee,
+                    metadata={
+                        "payment_method": payment_method,
+                        "payment_id": payment_result.get("payment_id"),
+                    },
                 )
-                db.add(transaction)
-                
+
                 await db.commit()
                 
                 self.logger.info(
@@ -545,7 +544,7 @@ class ProfitSharingService(LoggerMixin):
                         CreditAccount, CreditTransaction.account_id == CreditAccount.id
                     ).where(
                         CreditAccount.user_id == user_id,
-                        CreditTransaction.transaction_type == "welcome_bonus"
+                        CreditTransaction.transaction_type == CreditTransactionType.BONUS
                     )
                 )
                 
@@ -576,24 +575,18 @@ class ProfitSharingService(LoggerMixin):
                 welcome_profit_potential = welcome_config.get("welcome_profit_potential", 100)
                 welcome_credits = int(welcome_profit_potential * self.platform_fee_percentage)  # 25% of profit potential
                 
-                # Update credit account balances
-                balance_before = credit_account.available_credits
-                credit_account.available_credits += welcome_credits
-                credit_account.total_credits += welcome_credits
-                balance_after = credit_account.available_credits
-                
-                # Create welcome credit transaction
-                welcome_transaction = CreditTransaction(
-                    account_id=credit_account.id,
-                    amount=welcome_credits,  # Dynamic credit amount
+                await credit_ledger.add_credits(
+                    db,
+                    credit_account,
+                    credits=welcome_credits,
                     transaction_type=CreditTransactionType.BONUS,
                     description=f"Welcome Package: ${welcome_profit_potential:.0f} Free Profit Potential ({welcome_credits} credits)",
-                    balance_before=balance_before,
-                    balance_after=balance_after,
-                    source="system"
+                    source="profit_sharing_welcome",
+                    metadata={
+                        "welcome_profit_potential": welcome_profit_potential,
+                    },
                 )
-                
-                db.add(welcome_transaction)
+
                 await db.commit()
                 
                 # Add strategies based on admin configuration

--- a/app/services/strategy_marketplace_service.py
+++ b/app/services/strategy_marketplace_service.py
@@ -28,10 +28,11 @@ from app.core.logging import LoggerMixin
 from app.core.async_session_manager import DatabaseSessionMixin
 from app.models.trading import TradingStrategy, Trade
 from app.models.user import User
-from app.models.credit import CreditAccount, CreditTransaction, CreditTransactionType
+from app.models.credit import CreditAccount, CreditTransactionType
 from app.models.copy_trading import StrategyPublisher, StrategyPerformance
 from app.services.trading_strategies import trading_strategies_service
 from app.models.strategy_access import UserStrategyAccess
+from app.services.credit_ledger import credit_ledger, InsufficientCreditsError
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -1427,28 +1428,28 @@ class StrategyMarketplaceService(DatabaseSessionMixin, LoggerMixin):
                 # Check if user has enough credits (skip check for free strategies)
                 if cost > 0 and credit_account.available_credits < cost:
                     return {
-                        "success": False, 
+                        "success": False,
                         "error": f"Insufficient credits. Required: {cost}, Available: {credit_account.available_credits}"
                     }
-                
+
                 # Deduct credits (only for paid strategies)
                 if cost > 0:
-                    balance_before = credit_account.available_credits
-                    credit_account.available_credits -= cost
-                    credit_account.used_credits += cost
-                    balance_after = credit_account.available_credits
-                    
-                    # Record transaction (only for paid strategies)
-                    transaction = CreditTransaction(
-                        account_id=credit_account.id,
-                        transaction_type=CreditTransactionType.USAGE,
-                        amount=-cost,
-                        description=f"Strategy access: {strategy_id} ({subscription_type})",
-                        balance_before=balance_before,
-                        balance_after=balance_after,
-                        source="system"
-                    )
-                    db.add(transaction)
+                    try:
+                        await credit_ledger.consume_credits(
+                            db,
+                            credit_account,
+                            credits=cost,
+                            description=f"Strategy access: {strategy_id} ({subscription_type})",
+                            source="strategy_marketplace",
+                            transaction_type=CreditTransactionType.USAGE,
+                            metadata={
+                                "strategy_id": strategy_id,
+                                "subscription_type": subscription_type,
+                                "pricing_mode": subscription_type,
+                            },
+                        )
+                    except InsufficientCreditsError:
+                        return {"success": False, "error": "Insufficient credits"}
                 
                 # Add to user's active strategies
                 await self._add_to_user_strategy_portfolio(user_id, strategy_id, db)

--- a/app/services/user_onboarding_service.py
+++ b/app/services/user_onboarding_service.py
@@ -247,6 +247,7 @@ class UserOnboardingService(LoggerMixin):
                     description=f"Welcome bonus credits - {self.welcome_bonus_credits} + {self.referral_bonus_credits if referral_code else 0} referral",
                     source="onboarding_welcome",
                     metadata={"referral_code": referral_code},
+                    track_lifetime=False,
                 )
 
                 self.logger.info("💰 Credit account created",
@@ -272,6 +273,7 @@ class UserOnboardingService(LoggerMixin):
                         description="Welcome bonus credits - onboarding completion",
                         source="onboarding_welcome",
                         metadata={"referral_code": referral_code},
+                        track_lifetime=False,
                     )
 
                     self.logger.info("💰 Credit account updated with welcome bonus",
@@ -454,6 +456,7 @@ class UserOnboardingService(LoggerMixin):
                     description="Premium welcome package bonus",
                     source="onboarding_premium",
                     metadata={"package": "premium"},
+                    track_lifetime=False,
                 )
             
             # Provision premium strategy
@@ -524,6 +527,7 @@ class UserOnboardingService(LoggerMixin):
                     description=f"Referral bonus - new user {user_id[:8]}...",
                     source="onboarding_referral",
                     metadata={"referral_code": referral_code},
+                    track_lifetime=False,
                 )
             
             # Referee (new user) already got their referral bonus in _initialize_credit_account

--- a/frontend/src/hooks/useCredits.ts
+++ b/frontend/src/hooks/useCredits.ts
@@ -83,8 +83,12 @@ export const useCredits = () => {
       // Normalize response data to handle null/undefined values
       const balanceData = {
         available_credits: Number(response.data?.available_credits) || 0,
-        total_purchased_credits: Number(response.data?.total_credits) || 0,
-        total_used_credits: Number(response.data?.used_credits) || 0,
+        total_purchased_credits:
+          Number(
+            response.data?.total_purchased_credits ?? response.data?.total_credits
+          ) || 0,
+        total_used_credits:
+          Number(response.data?.total_used_credits ?? response.data?.used_credits) || 0,
         profit_potential: Number(response.data?.profit_potential) || 0,
         profit_earned_to_date: Number(response.data?.profit_earned_to_date) || 0,
         remaining_potential: Number(response.data?.remaining_potential) || 0,

--- a/tests/services/test_credit_ledger.py
+++ b/tests/services/test_credit_ledger.py
@@ -1,0 +1,232 @@
+"""Credit ledger integration tests for credit accounting flows."""
+
+import os
+import sys
+import uuid
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+if not hasattr(SQLiteTypeCompiler, "visit_UUID"):
+    def _visit_uuid(_, __, **_kw):  # pragma: no cover - SQLite shim
+        return "CHAR(36)"
+
+    SQLiteTypeCompiler.visit_UUID = _visit_uuid  # type: ignore[attr-defined]
+
+from app.models.credit import (  # noqa: E402
+    CreditAccount,
+    CreditStatus,
+    CreditTransaction,
+    CreditTransactionType,
+)
+from app.services.credit_ledger import (  # noqa: E402
+    InsufficientCreditsError,
+    credit_ledger,
+)
+
+
+@pytest_asyncio.fixture()
+async def ledger_session(tmp_path):
+    """Provide a fresh SQLite database session for each test case."""
+
+    db_path = tmp_path / "credit_ledger.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", future=True)
+
+    async with engine.begin() as conn:
+        await conn.execute(sa.text("PRAGMA foreign_keys=OFF"))
+        await conn.execute(sa.text("CREATE TABLE IF NOT EXISTS users (id CHAR(36) PRIMARY KEY)"))
+        await conn.execute(sa.text("CREATE TABLE IF NOT EXISTS credit_packs (id CHAR(36) PRIMARY KEY)"))
+        await conn.execute(sa.text("CREATE TABLE IF NOT EXISTS trades (id CHAR(36) PRIMARY KEY)"))
+        await conn.execute(sa.text("CREATE TABLE IF NOT EXISTS billing_history (id CHAR(36) PRIMARY KEY)"))
+        await conn.run_sync(
+            lambda connection: CreditAccount.__table__.create(connection, checkfirst=True)
+        )
+        await conn.run_sync(
+            lambda connection: CreditTransaction.__table__.create(connection, checkfirst=True)
+        )
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with SessionLocal() as session:
+            yield session
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+async def _create_user(session) -> uuid.UUID:
+    user_id = uuid.uuid4()
+    await session.execute(
+        sa.text("INSERT INTO users (id) VALUES (:id)"),
+        {"id": str(user_id)},
+    )
+    await session.flush()
+    return user_id
+
+
+@pytest.mark.asyncio()
+async def test_add_credits_updates_account_and_logs_transaction(ledger_session):
+    user_id = await _create_user(ledger_session)
+
+    account = await credit_ledger.get_account(
+        ledger_session,
+        user_id,
+        create_if_missing=True,
+    )
+
+    tx = await credit_ledger.add_credits(
+        ledger_session,
+        account,
+        credits=250,
+        transaction_type=CreditTransactionType.PURCHASE,
+        description="Starter pack purchase",
+        source="test-suite",
+        usd_value=Decimal("250"),
+        metadata={"order_id": "ORD-001"},
+    )
+
+    await ledger_session.commit()
+    await ledger_session.refresh(account)
+
+    assert account.available_credits == 250
+    assert account.total_credits == 250
+    assert account.total_purchased_credits == 250
+    assert tx.status == CreditStatus.ACTIVE
+    assert tx.balance_before == 0
+    assert tx.balance_after == 250
+
+
+@pytest.mark.asyncio()
+async def test_consume_credits_deducts_balance_and_stores_profit_context(ledger_session):
+    user_id = await _create_user(ledger_session)
+    account = await credit_ledger.get_account(
+        ledger_session,
+        user_id,
+        create_if_missing=True,
+    )
+
+    await credit_ledger.add_credits(
+        ledger_session,
+        account,
+        credits=300,
+        transaction_type=CreditTransactionType.PURCHASE,
+        description="Initial funding",
+        source="seed",
+    )
+
+    usage = await credit_ledger.consume_credits(
+        ledger_session,
+        account,
+        credits=75,
+        description="Live trade commission",
+        source="trade",
+        trade_id=uuid.uuid4(),
+        profit_amount=Decimal("300"),
+    )
+
+    await ledger_session.commit()
+    await ledger_session.refresh(account)
+
+    assert account.available_credits == 225
+    assert account.used_credits == 75
+    assert account.total_used_credits == 75
+    assert usage.amount == -75
+    assert usage.profit_amount_usd == Decimal("300")
+
+    transactions = await ledger_session.execute(
+        select(CreditTransaction).where(CreditTransaction.account_id == account.id)
+    )
+    recorded = transactions.scalars().all()
+    assert len(recorded) == 2
+    assert {tx.transaction_type for tx in recorded} == {
+        CreditTransactionType.PURCHASE,
+        CreditTransactionType.USAGE,
+    }
+
+
+@pytest.mark.asyncio()
+async def test_consume_credits_requires_sufficient_balance(ledger_session):
+    user_id = await _create_user(ledger_session)
+    account = await credit_ledger.get_account(
+        ledger_session,
+        user_id,
+        create_if_missing=True,
+    )
+
+    await credit_ledger.add_credits(
+        ledger_session,
+        account,
+        credits=20,
+        transaction_type=CreditTransactionType.BONUS,
+        description="Referral bonus",
+        source="referral",
+    )
+
+    await ledger_session.commit()
+
+    with pytest.raises(InsufficientCreditsError):
+        await credit_ledger.consume_credits(
+            ledger_session,
+            account,
+            credits=25,
+            description="Attempt over balance",
+            source="chat",
+        )
+
+
+@pytest.mark.asyncio()
+async def test_refund_restores_balances_and_usage_counters(ledger_session):
+    user_id = await _create_user(ledger_session)
+    account = await credit_ledger.get_account(
+        ledger_session,
+        user_id,
+        create_if_missing=True,
+    )
+
+    await credit_ledger.add_credits(
+        ledger_session,
+        account,
+        credits=120,
+        transaction_type=CreditTransactionType.PURCHASE,
+        description="Primary load",
+        source="wallet",
+    )
+
+    usage = await credit_ledger.consume_credits(
+        ledger_session,
+        account,
+        credits=60,
+        description="Signal execution",
+        source="signals",
+    )
+
+    refund = await credit_ledger.refund_credits(
+        ledger_session,
+        account,
+        credits=60,
+        description="Signal cancelled",
+        source="chat_refund",
+        reference_transaction_id=usage.id,
+    )
+
+    await ledger_session.commit()
+    await ledger_session.refresh(account)
+
+    assert account.available_credits == 120
+    assert account.used_credits == 0
+    assert account.total_used_credits == 0
+    assert refund.amount == 60
+    assert refund.meta_data.get("refund_for") == str(usage.id)

--- a/tests/services/test_unified_chat_service.py
+++ b/tests/services/test_unified_chat_service.py
@@ -25,6 +25,7 @@ from app.services.unified_chat_service import (
     TradingMode,
     UnifiedChatService,
 )
+from app.services.credit_ledger import InsufficientCreditsError
 
 
 def test_unified_chat_service_initializes_key_attributes():
@@ -229,3 +230,166 @@ async def test_strategy_management_prefetches_portfolio_once():
     _, _, _, context_arg = service._generate_complete_response.await_args.args
     assert context_arg["user_strategies"] is portfolio_payload
     assert context_arg["marketplace_strategies"] is marketplace_payload
+
+
+def test_resolve_chat_credit_cost_prefers_overrides():
+    service = UnifiedChatService()
+    service.chat_credit_cost_overrides = {
+        ConversationMode.ANALYSIS.value: 3,
+        ChatIntent.MARKET_ANALYSIS.value: 5,
+    }
+
+    mode_override = service._resolve_chat_credit_cost(
+        ChatIntent.PORTFOLIO_ANALYSIS,
+        ConversationMode.ANALYSIS,
+    )
+    intent_override = service._resolve_chat_credit_cost(
+        ChatIntent.MARKET_ANALYSIS,
+        ConversationMode.LIVE_TRADING,
+    )
+
+    assert mode_override == 3
+    assert intent_override == 5
+
+
+@pytest.mark.asyncio
+async def test_process_message_charges_credits_when_required():
+    service = UnifiedChatService()
+    session_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    service.sessions[session_id] = ChatSession(
+        session_id=session_id,
+        user_id=user_id,
+        interface=InterfaceType.WEB_CHAT,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        trading_mode=TradingMode.BALANCED,
+        created_at=datetime.utcnow(),
+        last_activity=datetime.utcnow(),
+        context={},
+        messages=[],
+    )
+
+    intent_payload = {
+        "intent": ChatIntent.MARKET_ANALYSIS,
+        "confidence": 0.96,
+        "requires_action": False,
+        "entities": {},
+    }
+
+    service._analyze_intent_unified = AsyncMock(return_value=intent_payload)
+    service._check_requirements = AsyncMock(
+        return_value={
+            "allowed": True,
+            "message": "All checks passed",
+            "credit_charge": {
+                "credits": 4,
+                "intent": ChatIntent.MARKET_ANALYSIS,
+                "conversation_mode": ConversationMode.LIVE_TRADING,
+            },
+        }
+    )
+    service._gather_context_data = AsyncMock(return_value={})
+    service._generate_complete_response = AsyncMock(
+        return_value={
+            "success": True,
+            "session_id": session_id,
+            "message_id": str(uuid.uuid4()),
+            "content": "analysis",
+            "intent": ChatIntent.MARKET_ANALYSIS.value,
+            "confidence": 0.96,
+            "timestamp": datetime.utcnow(),
+        }
+    )
+    service._charge_chat_interaction = AsyncMock(
+        return_value={
+            "transaction_id": str(uuid.uuid4()),
+            "credits": 4,
+            "intent": ChatIntent.MARKET_ANALYSIS.value,
+            "conversation_mode": ConversationMode.LIVE_TRADING.value,
+        }
+    )
+
+    result = await service.process_message(
+        "Give me a market update",
+        user_id,
+        session_id=session_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        stream=False,
+    )
+
+    service._charge_chat_interaction.assert_awaited_once_with(
+        user_id,
+        ChatIntent.MARKET_ANALYSIS,
+        ConversationMode.LIVE_TRADING,
+        4,
+    )
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_process_message_returns_action_when_credits_insufficient():
+    service = UnifiedChatService()
+    session_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    service.sessions[session_id] = ChatSession(
+        session_id=session_id,
+        user_id=user_id,
+        interface=InterfaceType.WEB_CHAT,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        trading_mode=TradingMode.BALANCED,
+        created_at=datetime.utcnow(),
+        last_activity=datetime.utcnow(),
+        context={},
+        messages=[],
+    )
+
+    intent_payload = {
+        "intent": ChatIntent.MARKET_ANALYSIS,
+        "confidence": 0.91,
+        "requires_action": False,
+        "entities": {},
+    }
+
+    service._analyze_intent_unified = AsyncMock(return_value=intent_payload)
+    service._check_requirements = AsyncMock(
+        return_value={
+            "allowed": True,
+            "message": "All checks passed",
+            "credit_charge": {
+                "credits": 6,
+                "intent": ChatIntent.MARKET_ANALYSIS,
+                "conversation_mode": ConversationMode.LIVE_TRADING,
+            },
+        }
+    )
+    service._gather_context_data = AsyncMock(return_value={})
+    service._generate_complete_response = AsyncMock(
+        return_value={
+            "success": True,
+            "session_id": session_id,
+            "message_id": str(uuid.uuid4()),
+            "content": "analysis",
+            "intent": ChatIntent.MARKET_ANALYSIS.value,
+            "confidence": 0.91,
+            "timestamp": datetime.utcnow(),
+        }
+    )
+    service._charge_chat_interaction = AsyncMock(
+        side_effect=InsufficientCreditsError("insufficient")
+    )
+
+    result = await service.process_message(
+        "Give me a market update",
+        user_id,
+        session_id=session_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        stream=False,
+    )
+
+    service._charge_chat_interaction.assert_awaited_once()
+    assert result["success"] is False
+    assert result["requires_action"] is True
+    assert result["action_data"]["type"] == "credit_purchase"
+    assert result["action_data"]["required_credits"] == 6


### PR DESCRIPTION
## Summary
- add a dedicated credit ledger service and migration for lifetime totals
- refactor credit-consuming endpoints and unified chat to use the ledger workflows
- update the frontend credit hook and add regression tests for ledger accounting and chat charging

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite+aiosqlite:///./test.db pytest tests/services/test_credit_ledger.py tests/services/test_unified_chat_service.py -k credit -q`
- `SECRET_KEY=test DATABASE_URL=sqlite:///./alembic_test.db alembic upgrade head` *(fails: migration history references missing revision 001)*

------
https://chatgpt.com/codex/tasks/task_e_68d9efae75c883229962c79a7b1ae556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized credit ledger, per-intent chat charging with configurable overrides, and lifetime credit fields (total purchased/used, last usage) exposed to clients.

* **Bug Fixes**
  * Improved payment idempotency/concurrency, consistent insufficient-credit handling (HTTP 402), and aligned profit/credit calculations.

* **Frontend**
  * Replaced static credit payloads with live-backed totals.

* **Tests**
  * Added integration tests for ledger and chat charging flows.

* **Documentation**
  * Added Credit System & Platform Audit Summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->