### PR TITLE
Handle missing Redis client at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         # Connect to Redis
         try:
             redis = await get_redis_client()
+            if redis is None:
+                raise RuntimeError("Redis client unavailable")
+
             await redis.ping()
             logger.info("Redis connected")
         except Exception as e:


### PR DESCRIPTION
## Summary
- guard the Redis startup ping to handle cases where the connection manager returns no client, ensuring degraded mode logging without attribute errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da1a3599308322a16ea3dc7b621609