### PR TITLE
Fix Redis client initialization during startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,6 +145,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         # Connect to Redis
         try:
             redis = await get_redis_client()
+            if redis is None:
+                raise RuntimeError("Redis client unavailable during startup")
+
             await redis.ping()
             logger.info("Redis connected")
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure the Redis connection manager recreates clients before health checks and only marks them unhealthy when creation fails
- reset health and failure counters when a client is created and force health checks when the manager is marked unhealthy
- clarify the startup degraded-mode log by raising a descriptive error when Redis is unavailable during initialization

## Testing
- python -m compileall app/core/redis.py

------
https://chatgpt.com/codex/tasks/task_e_68da1a3599308322a16ea3dc7b621609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection reliability with proactive health checks, faster recovery from failures, and automatic client recreation on errors to reduce downtime.
  * Enhanced handling of timeouts and parser-related errors, with safer concurrent recovery to maintain service stability.
  * Clarified startup error messaging when Redis is unavailable, aiding quicker troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->