### PR TITLE
Include cash balances in deployable capital estimation

### DIFF
--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -2168,7 +2168,11 @@ class UserOpportunityDiscoveryService(LoggerMixin):
         if credit_buying_power > 0:
             components["credit_buying_power_usd"] = float(credit_buying_power)
 
-        deployable_capital = max(portfolio_value, 0.0) + max(credit_buying_power, 0.0)
+        deployable_capital = (
+            max(portfolio_value, 0.0)
+            + max(cash_balance, 0.0)
+            + max(credit_buying_power, 0.0)
+        )
 
         if deployable_capital <= 0:
             deployable_capital = 10000.0


### PR DESCRIPTION
## Summary
- add cash balance to the deployable capital calculation and keep the metadata snapshot aligned
- cover the cash-only deployable scenario with a portfolio optimization test to prevent fallback usage

## Testing
- pytest tests/services/test_user_opportunity_discovery.py::test_portfolio_optimization_uses_cash_balance_when_portfolio_zero

------
https://chatgpt.com/codex/tasks/task_e_68db6b6aef988322a324943b132e2883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Opportunity sizing now includes available cash balance in deployable capital, ensuring accurate trade amounts even when portfolio value is zero or negative.
  - Reduces under-allocation and missed opportunities by correctly recognizing cash as deployable funds.
  - Existing caps and safeguards remain unchanged.

- Tests
  - Added coverage validating that deployable capital and trade sizing correctly use cash balance, producing expected opportunity count and values when portfolio value is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->