### PR TITLE
Add investor profile collection UI for chat

### DIFF
--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -514,27 +514,9 @@ class UnifiedChatService(LoggerMixin):
         for field in required:
             value = user_config.get(field)
             if field == "risk_tolerance":
-                normalized_value: Optional[str] = None
-                is_placeholder = False
-
-                if isinstance(value, str):
-                    candidate = value.strip().lower()
-                    # First check if already a valid normalized value
-                    if candidate in {"conservative", "moderate", "aggressive", "beast_mode"}:
-                        normalized_value = candidate
-                    # Then check for synonyms that need normalization
-                    elif candidate in {"balanced", "medium"}:
-                        normalized_value = "moderate"
-                        if candidate == "balanced":
-                            is_placeholder = True
-                    elif candidate == "beast":
-                        normalized_value = "beast_mode"
-                    elif candidate:
-                        normalized_value = self._normalize_risk_tolerance(candidate)
-                elif value is not None:
-                    normalized_value = self._normalize_risk_tolerance(str(value).lower())
-
-                if not normalized_value or is_placeholder:
+                normalized_value = self._normalize_risk_tolerance(str(value).strip().lower()) if value else None
+                # Only flag as missing if we have no value or the default "balanced" placeholder
+                if not normalized_value or (isinstance(value, str) and value.strip().lower() == "balanced"):
                     missing.append(field)
             elif field == "investment_amount":
                 amount = self._safe_float(value, None)

--- a/frontend/src/components/chat/InvestorProfilePrompt.tsx
+++ b/frontend/src/components/chat/InvestorProfilePrompt.tsx
@@ -82,11 +82,11 @@ const InvestorProfilePrompt: React.FC<InvestorProfilePromptProps> = ({
   }, [objectives, additionalObjective]);
 
   const constraintSelections = useMemo(() => {
-    const base = constraints.includes('None') ? ['None'] : constraints;
+    const base = constraints.includes('none') ? ['none'] : constraints;
     if (!additionalConstraint.trim()) {
       return base;
     }
-    return [...base.filter(option => option !== 'None'), additionalConstraint.trim()];
+    return [...base.filter(option => option !== 'none'), additionalConstraint.trim()];
   }, [constraints, additionalConstraint]);
 
   const toggleObjective = (value: string) => {

--- a/frontend/src/components/chat/InvestorProfilePrompt.tsx
+++ b/frontend/src/components/chat/InvestorProfilePrompt.tsx
@@ -261,15 +261,17 @@ const InvestorProfilePrompt: React.FC<InvestorProfilePromptProps> = ({
           </div>
 
           <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={onSkip}
-              disabled={isSubmitting}
-              className="justify-start text-muted-foreground"
-            >
-              I'll provide this later
-            </Button>
+            {onSkip && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onSkip}
+                disabled={isSubmitting}
+                className="justify-start text-muted-foreground"
+              >
+                I'll provide this later
+              </Button>
+            )}
 
             <Button type="submit" disabled={isSubmitting} className="gap-2">
               {isSubmitting ? 'Submitting...' : 'Save investor profile'}

--- a/frontend/src/components/chat/InvestorProfilePrompt.tsx
+++ b/frontend/src/components/chat/InvestorProfilePrompt.tsx
@@ -1,0 +1,284 @@
+import React, { useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+export interface InvestorProfileFormValues {
+  riskTolerance: string;
+  investmentAmount: string;
+  timeHorizon: string;
+  objectives: string[];
+  additionalObjective?: string;
+  constraints: string[];
+  additionalConstraint?: string;
+  notes?: string;
+}
+
+interface InvestorProfilePromptProps {
+  missingFields: string[];
+  onSubmit: (values: InvestorProfileFormValues) => Promise<void> | void;
+  onSkip?: () => void;
+  isSubmitting?: boolean;
+}
+
+const RISK_OPTIONS = [
+  { value: 'conservative', label: 'Conservative', description: 'Capital preservation, lower volatility' },
+  { value: 'balanced', label: 'Balanced', description: 'Even mix of growth and stability' },
+  { value: 'aggressive', label: 'Aggressive', description: 'Higher risk tolerance for stronger growth' },
+  { value: 'beast_mode', label: 'Beast Mode', description: 'Maximum risk appetite and velocity' }
+];
+
+const HORIZON_OPTIONS = [
+  { value: '0-12 months', label: '0-12 months' },
+  { value: '1-3 years', label: '1-3 years' },
+  { value: '3-5 years', label: '3-5 years' },
+  { value: '5+ years', label: '5+ years' }
+];
+
+const OBJECTIVE_OPTIONS = [
+  'Capital preservation',
+  'Steady income',
+  'Balanced growth',
+  'Aggressive growth',
+  'Speculative opportunities'
+];
+
+const CONSTRAINT_OPTIONS = [
+  'None',
+  'Limited liquidity',
+  'Tax sensitive',
+  'No leverage',
+  'ESG or sustainability focus'
+];
+
+const isFieldRequired = (field: string, missingFields: string[]) => missingFields.includes(field);
+
+const InvestorProfilePrompt: React.FC<InvestorProfilePromptProps> = ({
+  missingFields,
+  onSubmit,
+  onSkip,
+  isSubmitting = false
+}) => {
+  const [riskTolerance, setRiskTolerance] = useState('');
+  const [investmentAmount, setInvestmentAmount] = useState('');
+  const [timeHorizon, setTimeHorizon] = useState('');
+  const [objectives, setObjectives] = useState<string[]>([]);
+  const [additionalObjective, setAdditionalObjective] = useState('');
+  const [constraints, setConstraints] = useState<string[]>([]);
+  const [additionalConstraint, setAdditionalConstraint] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const objectiveSelections = useMemo(() => {
+    if (!additionalObjective.trim()) {
+      return objectives;
+    }
+    return [...objectives, additionalObjective.trim()];
+  }, [objectives, additionalObjective]);
+
+  const constraintSelections = useMemo(() => {
+    const base = constraints.includes('None') ? ['None'] : constraints;
+    if (!additionalConstraint.trim()) {
+      return base;
+    }
+    return [...base.filter(option => option !== 'None'), additionalConstraint.trim()];
+  }, [constraints, additionalConstraint]);
+
+  const toggleObjective = (value: string) => {
+    setObjectives((prev) =>
+      prev.includes(value) ? prev.filter((option) => option !== value) : [...prev, value]
+    );
+  };
+
+  const toggleConstraint = (value: string) => {
+    setConstraints((prev) => {
+      if (value === 'None') {
+        return prev.includes('None') ? [] : ['None'];
+      }
+
+      const withoutNone = prev.filter((option) => option !== 'None');
+      return withoutNone.includes(value)
+        ? withoutNone.filter((option) => option !== value)
+        : [...withoutNone, value];
+    });
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    await onSubmit({
+      riskTolerance,
+      investmentAmount,
+      timeHorizon,
+      objectives: objectiveSelections,
+      additionalObjective: additionalObjective.trim() || undefined,
+      constraints: constraintSelections,
+      additionalConstraint: additionalConstraint.trim() || undefined,
+      notes: notes.trim() || undefined
+    });
+  };
+
+  return (
+    <Card className="border-primary/20 bg-primary/5">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-primary">
+          Investor Profile Update Required
+        </CardTitle>
+        <CardDescription>
+          Share a few quick details so the AI can align opportunities and rebalancing with your goals.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>
+                Risk tolerance
+                {isFieldRequired('risk_tolerance', missingFields) && (
+                  <Badge variant="outline" className="ml-2 text-xs">Required</Badge>
+                )}
+              </Label>
+              <Select value={riskTolerance} onValueChange={setRiskTolerance}>
+                <SelectTrigger className={cn(isFieldRequired('risk_tolerance', missingFields) && !riskTolerance && 'border-primary')}>
+                  <SelectValue placeholder="Select your risk profile" />
+                </SelectTrigger>
+                <SelectContent>
+                  {RISK_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{option.label}</span>
+                        <span className="text-xs text-muted-foreground">{option.description}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                Investment amount (USD)
+                {isFieldRequired('investment_amount', missingFields) && (
+                  <Badge variant="outline" className="ml-2 text-xs">Required</Badge>
+                )}
+              </Label>
+              <Input
+                type="number"
+                min="0"
+                step="100"
+                placeholder="e.g. 10000"
+                value={investmentAmount}
+                onChange={(event) => setInvestmentAmount(event.target.value)}
+                className={cn(isFieldRequired('investment_amount', missingFields) && !investmentAmount && 'border-primary')}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                Time horizon
+                {isFieldRequired('time_horizon', missingFields) && (
+                  <Badge variant="outline" className="ml-2 text-xs">Required</Badge>
+                )}
+              </Label>
+              <Select value={timeHorizon} onValueChange={setTimeHorizon}>
+                <SelectTrigger className={cn(isFieldRequired('time_horizon', missingFields) && !timeHorizon && 'border-primary')}>
+                  <SelectValue placeholder="How long can you stay invested?" />
+                </SelectTrigger>
+                <SelectContent>
+                  {HORIZON_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                Objectives
+                {isFieldRequired('investment_objectives', missingFields) && (
+                  <Badge variant="outline" className="ml-2 text-xs">Required</Badge>
+                )}
+              </Label>
+              <div className="grid grid-cols-1 gap-2">
+                {OBJECTIVE_OPTIONS.map((option) => (
+                  <label key={option} className="flex items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={objectives.includes(option)}
+                      onCheckedChange={() => toggleObjective(option)}
+                    />
+                    <span>{option}</span>
+                  </label>
+                ))}
+              </div>
+              <Input
+                placeholder="Other objective"
+                value={additionalObjective}
+                onChange={(event) => setAdditionalObjective(event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>
+                Constraints
+                {isFieldRequired('constraints', missingFields) && (
+                  <Badge variant="outline" className="ml-2 text-xs">Required</Badge>
+                )}
+              </Label>
+              <div className="grid grid-cols-1 gap-2">
+                {CONSTRAINT_OPTIONS.map((option) => (
+                  <label key={option} className="flex items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={constraints.includes(option)}
+                      onCheckedChange={() => toggleConstraint(option)}
+                    />
+                    <span>{option}</span>
+                  </label>
+                ))}
+              </div>
+              <Input
+                placeholder="Other constraint"
+                value={additionalConstraint}
+                onChange={(event) => setAdditionalConstraint(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Anything else the AI should consider?</Label>
+            <Textarea
+              placeholder="Liquidity needs, preferred assets, exclusions, etc."
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={3}
+            />
+          </div>
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onSkip}
+              disabled={isSubmitting}
+              className="justify-start text-muted-foreground"
+            >
+              I'll provide this later
+            </Button>
+
+            <Button type="submit" disabled={isSubmitting} className="gap-2">
+              {isSubmitting ? 'Submitting...' : 'Save investor profile'}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InvestorProfilePrompt;

--- a/tests/services/test_unified_chat_service.py
+++ b/tests/services/test_unified_chat_service.py
@@ -206,15 +206,63 @@ def test_opportunity_prompt_uses_fractional_weights_and_trade_values():
         }
     }
 
+    context["user_config"] = {
+        "risk_tolerance": "balanced",
+        "investment_amount": 25000,
+        "time_horizon": "medium_term",
+        "investment_objectives": ["growth"],
+        "constraints": [],
+    }
+    context["allowed_symbols"] = ["BTCUSDT"]
+    context["portfolio_optimization"] = {
+        "primary_strategy": "risk_parity",
+        "strategies": [
+            {
+                "strategy": "risk_parity",
+                "expected_return": 0.15,
+                "expected_volatility": 0.09,
+                "sharpe_ratio": 1.2,
+                "confidence": 0.85,
+                "result": {"weights": {"BTCUSDT": 0.15}},
+                "suggested_trades": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "action": "buy",
+                        "notional_value": 1500,
+                        "quantity": 0.05,
+                        "target_weight": 0.15,
+                        "weight_change": 0.005,
+                        "reference_price": 30000,
+                    }
+                ],
+            }
+        ],
+    }
+
     prompt = service._build_response_prompt(
         "Show me portfolio optimization opportunities",
         ChatIntent.OPPORTUNITY_DISCOVERY,
         context,
     )
 
-    assert "Allocation Target: 15.0% of portfolio" in prompt
-    assert "Weight Change: 0.5%" in prompt
-    assert "Trade Size: ≈ $1,500.00" in prompt
+    assert "Expected annual return" in prompt
+    assert "Target Allocation: 15.0%" in prompt
+    assert "Suggested Trade Size: ≈ $1,500.00" in prompt
+
+
+def test_profile_parser_extracts_amount_and_constraints():
+    service = UnifiedChatService()
+
+    message = "I can invest $20k, avoid leverage and DOGE, but otherwise flexible"
+    updates = service._parse_investor_profile_response(
+        message,
+        list(service.INVESTOR_PROFILE_FIELDS),
+    )
+
+    assert updates.get("investment_amount") == pytest.approx(20000.0)
+    constraints = updates.get("constraints")
+    assert constraints is not None
+    assert "no_leverage" in constraints
 
 
 @pytest.mark.asyncio
@@ -287,3 +335,251 @@ async def test_strategy_management_prefetches_portfolio_once():
     _, _, _, context_arg = service._generate_complete_response.await_args.args
     assert context_arg["user_strategies"] is portfolio_payload
     assert context_arg["marketplace_strategies"] is marketplace_payload
+
+
+@pytest.mark.asyncio
+async def test_strategy_guidance_requires_investor_profile_before_response():
+    service = UnifiedChatService()
+
+    # Avoid hitting external systems during the test
+    service.memory_service.create_session = AsyncMock(return_value="session-test")
+    service.memory_service.update_session_context = AsyncMock(return_value=True)
+    service._analyze_intent_unified = AsyncMock(
+        return_value={
+            "intent": ChatIntent.OPPORTUNITY_DISCOVERY,
+            "confidence": 0.88,
+            "requires_action": False,
+            "entities": {},
+        }
+    )
+    service._gather_context_data = AsyncMock()
+    service._generate_complete_response = AsyncMock()
+
+    user_id = str(uuid.uuid4())
+
+    first_response = await service.process_message(
+        message="Find me the best opportunities",
+        user_id=user_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+
+    assert first_response["success"] is False
+    assert first_response["requires_action"] is True
+    assert "risk tolerance" in first_response["content"].lower()
+    service._generate_complete_response.assert_not_awaited()
+
+    session_id = first_response["session_id"]
+    pending_context = service.sessions[session_id].context
+    assert "awaiting_profile_fields" in pending_context
+
+    second_prompt = await service.process_message(
+        message="I'm conservative with a long-term horizon focused on income",
+        user_id=user_id,
+        session_id=session_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+
+    assert second_prompt["success"] is False
+    assert second_prompt.get("requires_action") is True
+    assert "capital you want the plan to manage" in second_prompt["content"].lower()
+
+    final_ack = await service.process_message(
+        message="I can invest $15,000 and have no constraints",
+        user_id=user_id,
+        session_id=session_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+
+    assert final_ack["success"] is True
+    assert final_ack.get("metadata", {}).get("preference_update") is True
+
+    assert "awaiting_profile_fields" not in service.sessions[session_id].context
+
+    stored_config = await service._get_user_config(user_id)
+    assert stored_config.get("risk_tolerance") == "conservative"
+    assert stored_config.get("time_horizon") == "long_term"
+    assert stored_config.get("investment_amount") == pytest.approx(15000.0)
+    assert stored_config.get("constraints") == []
+    assert stored_config.get("investment_objectives") == ["income"]
+
+    service._generate_complete_response.reset_mock()
+    service._check_requirements = AsyncMock(
+        return_value={
+            "allowed": True,
+            "message": "All checks passed",
+            "user_config": {
+                "risk_tolerance": "conservative",
+                "investment_amount": 15000.0,
+                "time_horizon": "long_term",
+                "investment_objectives": ["income"],
+                "constraints": [],
+                "trading_mode": TradingMode.CONSERVATIVE.value,
+                "operation_mode": "assisted",
+            },
+        },
+    )
+
+    service._gather_context_data.reset_mock()
+    service._gather_context_data.return_value = {
+        "opportunities": {"opportunities": [], "user_profile": {}},
+        "user_config": {
+            "risk_tolerance": "conservative",
+            "investment_amount": 15000.0,
+            "time_horizon": "long_term",
+            "investment_objectives": ["income"],
+            "constraints": [],
+        },
+    }
+
+    service._generate_complete_response.return_value = {"success": True, "content": "ready"}
+
+    final_response = await service.process_message(
+        message="Find me the best opportunities",
+        user_id=user_id,
+        session_id=session_id,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+
+    assert final_response["success"] is True
+    service._generate_complete_response.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_opportunity_prompts_reflect_profile_differences():
+    service = UnifiedChatService()
+
+    service.memory_service.create_session = AsyncMock(return_value="session-pref")
+    service.memory_service.update_session_context = AsyncMock(return_value=True)
+    service._save_conversation = AsyncMock(return_value=None)
+
+    conservative_config = {
+        "risk_tolerance": "conservative",
+        "investment_amount": 20000.0,
+        "time_horizon": "long_term",
+        "investment_objectives": ["income"],
+        "constraints": [],
+        "trading_mode": TradingMode.CONSERVATIVE.value,
+        "operation_mode": "assisted",
+    }
+    aggressive_config = {
+        "risk_tolerance": "aggressive",
+        "investment_amount": 5000.0,
+        "time_horizon": "short_term",
+        "investment_objectives": ["growth"],
+        "constraints": ["no_leverage"],
+        "trading_mode": TradingMode.AGGRESSIVE.value,
+        "operation_mode": "assisted",
+    }
+
+    base_opportunities = [
+        {
+            "strategy_name": "AI Portfolio Optimization - Core",
+            "symbol": "BTCUSDT",
+            "confidence_score": 0.9,
+            "profit_potential_usd": 1200,
+            "metadata": {
+                "risk_level": "low",
+                "time_horizon": "long_term",
+                "objective": "income",
+                "amount": "10%",
+            },
+        },
+        {
+            "strategy_name": "High Beta Momentum",
+            "symbol": "DOGEUSDT",
+            "confidence_score": 0.75,
+            "profit_potential_usd": 2500,
+            "metadata": {
+                "risk_level": "high",
+                "time_horizon": "short_term",
+                "objective": "growth",
+                "amount": "8%",
+            },
+        },
+    ]
+
+    async def gather_context_side_effect(*args, **kwargs):
+        user_config = kwargs.get("user_config") or {}
+        risk = user_config.get("risk_tolerance", "balanced")
+        if risk == "conservative":
+            allowed = ["BTCUSDT"]
+            strategy_tag = "risk_parity"
+        else:
+            allowed = ["BTCUSDT", "DOGEUSDT"]
+            strategy_tag = "kelly_criterion"
+
+        return {
+            "opportunities": {
+                "opportunities": list(base_opportunities),
+                "user_profile": {"risk_profile": user_config.get("risk_tolerance", "balanced")},
+            },
+            "user_config": user_config,
+            "allowed_symbols": allowed,
+            "portfolio_optimization": {
+                "primary_strategy": strategy_tag,
+                "strategies": [
+                    {
+                        "strategy": strategy_tag,
+                        "expected_return": 0.12 if risk == "conservative" else 0.25,
+                        "expected_volatility": 0.06 if risk == "conservative" else 0.2,
+                        "sharpe_ratio": 1.3,
+                        "confidence": 0.8,
+                        "result": {"weights": {symbol: 0.5 for symbol in allowed}},
+                        "suggested_trades": [],
+                    }
+                ],
+            },
+        }
+
+    service._analyze_intent_unified = AsyncMock(
+        return_value={
+            "intent": ChatIntent.OPPORTUNITY_DISCOVERY,
+            "confidence": 0.95,
+            "requires_action": False,
+            "entities": {},
+        }
+    )
+
+    service._check_requirements = AsyncMock(
+        side_effect=[
+            {
+                "allowed": True,
+                "message": "All checks passed",
+                "user_config": conservative_config,
+            },
+            {
+                "allowed": True,
+                "message": "All checks passed",
+                "user_config": aggressive_config,
+            },
+        ]
+    )
+
+    service._gather_context_data = AsyncMock(side_effect=gather_context_side_effect)
+    service.chat_ai.generate_response = AsyncMock(
+        return_value={"success": True, "content": "ok", "elapsed_time": 0.1}
+    )
+
+    conservative_response = await service.process_message(
+        message="Share personalized opportunities",
+        user_id="profile-user",
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+    assert conservative_response["success"] is True
+
+    conservative_prompt = service.chat_ai.generate_response.await_args_list[0].kwargs["prompt"]
+    assert "BTCUSDT" in conservative_prompt
+    assert "DOGEUSDT" not in conservative_prompt
+    assert "risk tolerance conservative" in conservative_prompt.lower()
+
+    aggressive_response = await service.process_message(
+        message="Share personalized opportunities",
+        user_id="profile-user",
+        session_id=conservative_response["session_id"],
+        conversation_mode=ConversationMode.LIVE_TRADING,
+    )
+    assert aggressive_response["success"] is True
+
+    aggressive_prompt = service.chat_ai.generate_response.await_args_list[1].kwargs["prompt"]
+    assert "DOGEUSDT" in aggressive_prompt
+    assert "risk tolerance aggressive" in aggressive_prompt.lower()


### PR DESCRIPTION
## Summary
- allow the unified chat endpoint to return `requires_action` payloads rather than raising errors so follow-up forms render correctly in clients
- teach the chat store to track pending profile collection requests and surface a tailored questionnaire inside the trading interface
- add a reusable investor profile prompt that captures risk tolerance, horizons, objectives, constraints, and notes for submission back to the assistant

## Testing
- pytest tests/services/test_unified_chat_service.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db567b476c8322aa2548f45ab9724a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Investor profile workflow in chat with guided questionnaire, submit/skip/loading UI; frontend prompt component added.
  - Portfolio optimization integrated into analysis and opportunity suggestions, tailored to user profile and trading mode.
  - Chat pending-action flow: assistant can emit actionable prompts that persist until completed.

- **Enhancements**
  - Responses can request user action and include structured action data; intent and profile normalization improved.
  - User profile preferences: retrieve, update, in-memory fallback and persistence.

- **Tests**
  - Expanded coverage for profile collection, portfolio optimization prompts, and profile-driven differences in opportunities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->