### PR TITLE
Ensure change request reviews persist status

### DIFF
--- a/app/services/strategy_submission_service.py
+++ b/app/services/strategy_submission_service.py
@@ -417,10 +417,13 @@ class StrategySubmissionService(DatabaseSessionMixin, LoggerMixin):
             submission.strategy_config[self.REVIEW_STATE_KEY] = "rejected"
             self._append_history_entry(submission, "rejected", reviewer.email, comment)
         elif action == "request_changes":
-            submission.status = StrategyStatus.CHANGES_REQUESTED
+            changes_requested_status = StrategyStatus.CHANGES_REQUESTED
+            submission.status = changes_requested_status
             submission.reviewed_at = now
             submission.reviewer_feedback = comment
-            submission.strategy_config[self.REVIEW_STATE_KEY] = "changes_requested"
+            submission.strategy_config[self.REVIEW_STATE_KEY] = (
+                changes_requested_status.value
+            )
             self._append_history_entry(
                 submission, "changes_requested", reviewer.email, comment
             )


### PR DESCRIPTION
## Summary
- ensure change-requested admin reviews persist the dedicated status value on the ORM model
- keep the strategy config review_state in sync with the changes-requested status entry

## Testing
- pytest tests/services/test_strategy_marketplace_integration.py::test_request_changes_sets_changes_requested_status

------
https://chatgpt.com/codex/tasks/task_e_68dbea0052c083228249e3779d0f9962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures consistent status updates when requesting changes on strategy submissions, reducing potential mismatches in review status and workflow.
* **Refactor**
  * Replaced hardcoded status strings with centralized status values to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->