### PR TITLE
Fix credit profit query for legacy text trade statuses

### DIFF
--- a/app/api/v1/endpoints/credits.py
+++ b/app/api/v1/endpoints/credits.py
@@ -25,7 +25,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks, Header
 from pydantic import BaseModel, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, and_, or_, desc, func
+from sqlalchemy import select, and_, or_, desc, func, cast, String
 from sqlalchemy.exc import IntegrityError
 
 from app.core.config import get_settings
@@ -216,15 +216,13 @@ async def get_credit_balance(
         # Get total profit earned to date with safe query
         try:
             completed_status = TradeStatus.COMPLETED.value
-            normalized_statuses = {
-                completed_status,
-                str(completed_status).upper(),
-            }
+            normalized_status = str(completed_status).upper()
+            status_text = func.upper(cast(Trade.status, String))  # Cast to text for legacy rows
 
             profit_stmt = select(func.sum(Trade.profit_realized_usd)).where(
                 and_(
                     Trade.user_id == current_user.id,
-                    Trade.status.in_(list(normalized_statuses)),  # Use plain strings to avoid enum binding
+                    status_text == normalized_status,
                     Trade.is_simulation.is_(False),  # Use .is_() for proper boolean comparison
                     Trade.profit_realized_usd > 0
                 )


### PR DESCRIPTION
## Summary
- update the credits balance profit aggregation to compare trade statuses using plain strings
- include both the enum value and an uppercase fallback to avoid enum binding issues with legacy text columns

## Testing
- not run (requires database with legacy text trade statuses)


------
https://chatgpt.com/codex/tasks/task_e_68dbe9cf751483229ee5b61a82b0c9a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credit balance calculation so completed trades are recognized regardless of status format or casing.
  * Prevents intermittent undercounting of completed trades, improving accuracy and reliability of profit and credit totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->