### PR TITLE
Use shared market analysis service in unified chat

### DIFF
--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -43,7 +43,7 @@ from app.services.chat_memory import ChatMemoryService
 # Note: unified_ai_manager is imported lazily in methods to avoid initialization at module load
 
 # Import all service engines
-from app.services.market_analysis_core import MarketAnalysisService
+from app.services.market_analysis import MarketAnalysisService, market_analysis_service
 from app.services.portfolio_risk import OptimizationStrategy
 from app.services.portfolio_risk_core import PortfolioRiskService
 from app.services.trading_strategies import TradingStrategiesService
@@ -180,7 +180,7 @@ class UnifiedChatService(LoggerMixin):
         self.trade_executor = TradeExecutionService()
 # Direct service integrations - no adapters needed
         self.telegram_core = TelegramCommanderService()
-        self.market_analysis = MarketAnalysisService()
+        self.market_analysis = market_analysis_service
         self.portfolio_risk = PortfolioRiskService()
         self.trading_strategies = TradingStrategiesService()
         self.strategy_marketplace = strategy_marketplace_service


### PR DESCRIPTION
## Summary
- update the unified chat service to import the market analysis singleton from the compatibility wrapper
- reuse the shared market analysis instance so chat flows and the REST endpoint leverage the same cache

## Testing
- SECRET_KEY=test DATABASE_URL=sqlite+aiosqlite:///./test.db python - <<'PY'
import asyncio
from app.services.unified_chat_service import UnifiedChatService
from app.services.market_analysis import market_analysis_service

async def main():
    service = UnifiedChatService()
    print('market_analysis is shared instance:', service.market_analysis is market_analysis_service)

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68de2b53674c832283cc800c99b3f60d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified market analysis integration by switching to a shared service instance for more consistent behavior across features.
* **Performance**
  * Minor efficiency improvements that may slightly reduce resource usage during market analysis operations.
* **Reliability**
  * Increased stability by standardizing how market analysis is accessed throughout the app.
* **Chores**
  * Internal wiring updates; no changes to user-facing functionality or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->