### PR TITLE
Add Redis-backed market overview caching and background warmer

### DIFF
--- a/app/services/market_analysis_core.py
+++ b/app/services/market_analysis_core.py
@@ -30,6 +30,7 @@ Functions migrated:
 
 import asyncio
 import copy
+import json
 import os
 import time
 from datetime import datetime, timedelta
@@ -4406,12 +4407,48 @@ class MarketAnalysisService(LoggerMixin):
     async def get_market_overview(self) -> Dict[str, Any]:
         """Get comprehensive market overview for adaptive timing and decision making."""
         start_time = time.time()
+        cache_key = self._build_cache_key("market_overview")
+        redis_client = None
 
         try:
-            cache_key = self._build_cache_key("market_overview")
             cached_response = await self._get_cached_result(cache_key)
             if cached_response:
                 return cached_response
+
+            # Attempt to hydrate from Redis before calling external APIs
+            try:
+                from app.core.redis import get_redis_client  # Local import to avoid circular deps
+
+                redis_client = await get_redis_client()
+            except Exception as redis_error:  # pragma: no cover - defensive logging
+                self.logger.debug(
+                    "Redis unavailable for market overview lookup",
+                    error=str(redis_error),
+                )
+                redis_client = None
+
+            if redis_client:
+                try:
+                    cached_bytes = await redis_client.get(cache_key)
+                except Exception as redis_error:  # pragma: no cover - defensive logging
+                    self.logger.warning(
+                        "Failed to read market overview from Redis",
+                        error=str(redis_error),
+                    )
+                else:
+                    if cached_bytes:
+                        try:
+                            if isinstance(cached_bytes, bytes):
+                                cached_bytes = cached_bytes.decode("utf-8")
+                            redis_payload = json.loads(cached_bytes)
+                        except (json.JSONDecodeError, TypeError) as decode_error:
+                            self.logger.warning(
+                                "Failed to decode market overview cache payload",
+                                error=str(decode_error),
+                            )
+                        else:
+                            await self._set_cached_result(cache_key, redis_payload, pre_processed=True)
+                            return self._mark_cache_hit(redis_payload)
 
             from app.services.market_data_feeds import get_market_overview
 
@@ -4466,6 +4503,38 @@ class MarketAnalysisService(LoggerMixin):
 
             response_with_metadata = self._prepare_for_cache(response)
             await self._set_cached_result(cache_key, response_with_metadata, pre_processed=True)
+
+            # Persist to Redis with a short TTL so subsequent workers can reuse it
+            if not redis_client:
+                try:
+                    from app.core.redis import get_redis_client  # Local import avoids module-level cost
+
+                    redis_client = await get_redis_client()
+                except Exception as redis_error:  # pragma: no cover - defensive logging
+                    self.logger.debug(
+                        "Redis unavailable when persisting market overview",
+                        error=str(redis_error),
+                    )
+                    redis_client = None
+
+            if redis_client and response_with_metadata.get("success"):
+                try:
+                    ttl_seconds = 60
+                    await redis_client.setex(
+                        cache_key,
+                        ttl_seconds,
+                        json.dumps(response_with_metadata, default=str),
+                    )
+                    await redis_client.set(
+                        "market_analysis:last_overview_refresh",
+                        datetime.utcnow().isoformat(),
+                    )
+                except Exception as redis_error:  # pragma: no cover - defensive logging
+                    self.logger.warning(
+                        "Failed to hydrate Redis market overview cache",
+                        error=str(redis_error),
+                    )
+
             return response_with_metadata
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- consult Redis before calling external providers in `MarketAnalysisService.get_market_overview` and persist fresh data with a 60s TTL
- schedule a cache warmer background coroutine that refreshes market overview and price snapshots into Redis on a short interval
- expose cache freshness timestamps and ages on the Redis health endpoint to monitor data staleness

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de2b7079e08322be1ae2e59e99383e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Background cache warmer preloads market overview and price snapshots for faster responses.
  * Health check now reports cache freshness metrics for market data.

* Improvements
  * Market overview is cached in Redis with graceful fallback to in-memory when Redis is unavailable.
  * Reduced latency and fewer external API calls through smarter caching and TTLs.
  * More robust startup by integrating the cache warmer into deferred and full service startup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->