### PR TITLE
Route Telegram chat through unified AI persona

### DIFF
--- a/TELEGRAM_CHAT_BEHAVIOR_REVIEW.md
+++ b/TELEGRAM_CHAT_BEHAVIOR_REVIEW.md
@@ -1,0 +1,124 @@
+# Telegram Chat Behavior Review
+
+## Context
+This document reviews the Telegram conversation between the user and the AR Crypto Agent connected to CryptoUniverse. The goal is to evaluate whether the assistant behaves like a sophisticated AI money manager and to outline actionable improvements for a natural, expert-level user experience.
+
+## Summary of Observed Behavior
+- **Inconsistent account awareness.** The assistant initially reports a $0.00 portfolio and moments later reports a $3.7k balance without acknowledging the discrepancy or explaining the update.
+- **Fragmented persona.** The voice oscillates between “strategic portfolio manager” and generic chatbot, eroding credibility that a seasoned advisor is behind the messages.
+- **Limited conversational comprehension.** Direct, reasonable questions such as “What strategies do I have?” or “What strategies do I have access to?” repeatedly trigger the same fallback response instead of acknowledging available marketplace strategies or clarifying the misunderstanding.
+- **Overly canned fallback prompts.** The repeated “I’m not sure what you’re asking about” message appears even when the user’s intent is clear, creating frustration and diminishing perceived intelligence.
+- **Robotic formatting.** Heavy emoji usage and FAQ-style bullet lists make the conversation feel scripted instead of consultative.
+- **Generic opportunity summaries.** The opportunity report claims 238 trading opportunities but only repeats the Kelly Criterion item three times, provides no supporting metrics (confidence, timeframe, exchange), and does not offer next steps beyond `/opportunities`, which simply restates the same vague summary.
+- **Lack of conversational continuity.** The agent does not reference earlier portfolio details, risk level, or credits when making recommendations; it feels like disconnected one-off replies rather than an ongoing relationship with a portfolio manager.
+- **Credit guidance without actionability.** The system reports “0 credits” but does not explain the implications for trading capacity or provide upgrade options.
+
+## Impact on Perceived Sophistication
+- The conversation fails to convey trustworthiness or expertise expected from an AI money manager. Users are likely to question data accuracy because of conflicting balances and the inability to answer basic questions.
+- The fallback-heavy tone feels more like a scripted chatbot than an expert advisor capable of nuanced, context-aware guidance.
+- Opportunity summaries without actionable insight (symbols, entry points, rationale) do not demonstrate the platform’s advanced analytics.
+- The platform’s enterprise-grade positioning is undermined when the Telegram touchpoint feels like a low-cost support bot instead of a proactive portfolio strategist.
+
+## Enterprise-Grade Conversation Flow Blueprint
+1. **State hydration layer**
+   - Fetch latest portfolio, credit balance, risk profile, and active strategies at the start of each turn.
+   - Detect discrepancies between cached and live values; transparently acknowledge updates when values change mid-conversation.
+2. **Intent triage**
+   - Classify the user message into core domains: portfolio insight, strategies, opportunities, trade execution, credits, or general help.
+   - If confidence is below threshold, ask a clarifying question before defaulting to a fallback.
+3. **Context synthesis**
+   - Merge conversation history with hydrated state to craft a response plan (e.g., “User previously asked about strategies; include references to Kelly Criterion insights.”).
+4. **Expert narrative generation**
+   - Produce a 2–4 sentence primary response using professional yet approachable tone.
+   - Add optional lightweight structure (short bullets, tables) only when it improves clarity of complex financial data.
+5. **Action framing**
+   - Suggest concrete next steps, such as reviewing the top three opportunities, activating a strategy, or purchasing credits, always tied to the user’s risk settings and capital.
+6. **Logging and learning**
+   - Record intents, state snapshots, and user feedback to refine future intent models and to support compliance auditing.
+
+## Recommended Improvements
+1. **State consistency and transparency**
+   - Ensure the bot synchronizes with portfolio services before responding.
+   - If new data arrives, acknowledge the change: e.g., “I just synced with your Binance and KuCoin accounts; your total is now $3,709.20.”
+2. **Intent understanding and graceful clarification**
+   - Expand intent recognition to cover “What strategies do I have?” and similar phrasing.
+   - When information is unavailable, respond with a clarification path (“I don’t see strategies linked to your account yet. Would you like me to suggest portfolio, algorithmic, or derivatives options?”) instead of a generic fallback.
+3. **Expert tone with human warmth**
+   - Use concise, confident language that references portfolio metrics (“Given your balanced profile and current holdings, here’s how we can deploy credits effectively…”).
+   - Mirror human conversation patterns—acknowledge questions, confirm understanding, and offer next steps.
+4. **Actionable opportunity presentation**
+   - Provide top opportunities with key data: asset, direction, confidence, time horizon, suggested allocation, and rationale.
+   - Offer contextual actions (“Shall I allocate 5% of your Binance capital to the top Kelly Criterion opportunity?”).
+5. **Conversation continuity**
+   - Persist relevant session context (risk profile, credits, latest balance) and reference it naturally in future replies.
+   - When a user asks about strategies, connect back to earlier recommendations or explain how to enable them.
+6. **Credit management guidance**
+   - Tie credit balance updates to actionable advice (“You currently have 0 credits. Purchasing 100 credits would unlock $10,000 in trading capital at your Standard Tier.”).
+7. **Persona alignment and voice guidelines**
+   - Lock the assistant persona to “Alex, your senior portfolio manager with 15 years of experience,” and keep responses within that frame.
+   - Remove template-like emoji lists unless clarifying complex data; prefer natural paragraphs with optional lightweight structuring for clarity.
+8. **Progressive disclosure of detail**
+   - Start with an executive summary and invite the user to request deeper analysis, rather than overwhelming them with lists or forcing them to re-issue commands.
+
+## Natural Language Response Library
+These patterns illustrate how to stay conversational while signalling deep expertise and actionable guidance.
+
+### Portfolio Check-In
+> **User:** What’s my portfolio balance?
+>
+> **Assistant:** “Your portfolio is currently valued at $3,709.20. XRP, ADA, and AAVE make up about 75% of your holdings, and all three are slightly up in the last 24 hours. Want me to drill into any of those positions or scan for rebalancing opportunities?”
+
+### Strategy Availability
+> **User:** What strategies do I have access to?
+>
+> **Assistant:** “You’re not running automated strategies yet, but you can activate any of our marketplace models. For your balanced, medium-risk profile I’d start with Kelly Criterion portfolio optimization, AI futures hedging, or our algorithmic pattern recognition suite. Curious about how each one deploys capital?”
+
+### Opportunity Spotlight
+> **User:** Show me opportunities today.
+>
+> **Assistant:** “I’m tracking 238 setups right now. For your portfolio size, these three stand out:
+> • **BTC long – Kelly Criterion signal.** Potential $1,800 upside on $5K allocation, 68% win rate, momentum building off $63K support.
+> • **ETH/BTC pair trade.** Targets $1,200 on $4K with medium-low risk as ETH is lagging BTC—classic mean reversion window.
+> • **SOL accumulation.** $900 potential on $3K allocation, volume confirming breakout.
+>
+> Want me to reserve capital for one of these or explore other sectors?”
+
+### Credit Coaching
+> **User:** What’s my credit balance?
+>
+> **Assistant:** “You currently have 0 credits, so we’re limited to monitoring and paper analysis. Adding 100 credits would unlock roughly $10,000 in live trading capital at your Standard Tier conversion rate. Should I walk you through the upgrade options?”
+
+### Clarifying Unclear Requests
+> **User:** I need help with strategies.
+>
+> **Assistant:** “Happy to help. Are you looking for a rundown of the strategies you can activate, or guidance on which strategies are already influencing your portfolio today?”
+
+## Implementation TODOs
+- [x] Build a persona middleware that injects “Alex, senior portfolio manager” context and enforces tone/formatting rules.
+- [x] Extend the intent classifier to cover strategy-related phrasing, credit inquiries, and opportunity deep-dives with higher recall.
+- [x] Implement a state synchronization guard that confirms portfolio and credit data freshness before each reply.
+- [x] Design an opportunity ranking module that surfaces the top 3–5 ideas with metrics tailored to the user’s risk profile and capital.
+- [x] Create reusable response templates (in natural language) for portfolio, strategy, opportunity, and credit dialogues.
+- [x] Add clarifying-question logic when intent confidence is medium instead of jumping straight to fallbacks.
+- [x] Integrate credit-to-capital conversion data so recommendations include concrete next steps for upgrading.
+- [x] Establish telemetry to log conversation flow decisions for continuous improvement and compliance tracking.
+
+## Example of Improved Telegram Dialogue
+> **User:** What strategies do I have access to?
+>
+> **Assistant:** You currently haven’t activated any strategies. Based on your balanced mode and medium risk setting, I can enable:
+> • **Kelly Criterion Portfolio** – Diversifies across top-moving assets with dynamic position sizing.
+> • **AI Futures Guard** – Uses futures positions to hedge downside while targeting moderate gains.
+>
+> Would you like a quick summary of each or shall I activate one for a paper-trading run?
+>
+> **User:** Show me opportunities today.
+>
+> **Assistant:** I’m tracking 238 setups. For your current balances, here’s where I’d focus first:
+> 1. **BTC long via Kelly Criterion** – Allocate $5K, projected $1.8K upside, medium risk, bullish momentum confirmed on daily chart.
+> 2. **ETH/BTC spread** – $4K allocation, $1.2K potential, medium-low risk, capitalizes on near-term mean reversion.
+> 3. **SOL accumulation** – $3K allocation, $900 potential, medium risk, breakout supported by rising volume.
+>
+> I can stage orders for any of these or surface more ideas in derivatives, spot, or algorithmic categories—what’s the next move?
+
+Implementing the above behaviors will help the Telegram agent reflect the sophistication of the CryptoUniverse platform and build user confidence in its money-management capabilities.

--- a/app/api/v1/endpoints/telegram.py
+++ b/app/api/v1/endpoints/telegram.py
@@ -13,7 +13,6 @@ Features:
 """
 
 import asyncio
-import hashlib
 import secrets
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any

--- a/app/api/v1/endpoints/telegram.py
+++ b/app/api/v1/endpoints/telegram.py
@@ -29,10 +29,13 @@ from app.core.database import get_database
 from app.api.v1.endpoints.auth import get_current_user
 from app.models.user import User
 from app.models.telegram_integration import UserTelegramConnection, TelegramMessage
-from app.services.telegram_core import TelegramCommanderService as TelegramService
+from app.services.telegram_core import telegram_commander_service
 from app.services.telegram_commander import MessageType
 from app.services.rate_limit import rate_limiter
-from app.services.unified_chat_service import InterfaceType, ConversationMode
+from app.services.unified_ai_manager import (
+    unified_ai_manager,
+    InterfaceType as UnifiedInterfaceType,
+)
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -40,7 +43,7 @@ logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 # Initialize Telegram service
-telegram_service = TelegramService()
+telegram_service = telegram_commander_service
 
 
 # Request/Response Models
@@ -748,35 +751,7 @@ async def _process_authenticated_message(
         if message_text.startswith("/"):
             response = await _process_telegram_command(connection, message_text, db)
         else:
-            # Try UnifiedChatService first
-            try:
-                from app.services.unified_chat_service import unified_chat_service
-                
-                # Process through unified chat (singleton instance)
-                chat_result = await unified_chat_service.process_message(
-                    message=message_text,
-                    user_id=str(connection.user_id),
-                    session_id=f"telegram_{chat_id}",
-                    interface=InterfaceType.TELEGRAM,
-                    conversation_mode=ConversationMode.LIVE_TRADING,
-                    stream=False
-                )
-                
-                if chat_result.get("success"):
-                    response = chat_result.get("content", chat_result.get("response", ""))
-                    
-                    # If we got an empty response, fall back
-                    if not response:
-                        logger.warning("UnifiedChat returned empty response")
-                        response = await _process_natural_language(connection, message_text, db)
-                else:
-                    logger.warning(f"UnifiedChat failed: {chat_result.get('error')}")
-                    response = await _process_natural_language(connection, message_text, db)
-                    
-            except Exception as e:
-                logger.error(f"Failed to use UnifiedChat: {e}", exc_info=True)
-                # Fallback to simple processing
-                response = await _process_natural_language(connection, message_text, db)
+            response = await _process_natural_language(connection, message_text, db)
         
         # Send response
         if response:
@@ -852,58 +827,87 @@ async def _process_natural_language(
     message_text: str,
     db: AsyncSession
 ) -> Optional[str]:
-    """Process natural language message using simple keyword matching."""
+    """Process natural language messages through the unified AI persona pipeline."""
+    del db  # Natural language routing no longer needs the raw database handle directly
+
+    message = (message_text or "").strip()
+    if not message:
+        return (
+            "I didn't catch a question there. Let me know what you want to review—portfolio status, strategies,"
+            " or fresh trade ideas—and I'll walk you through it."
+        )
+
+    context = {
+        "chat_id": connection.telegram_chat_id,
+        "platform": "telegram",
+        "interface_session": f"telegram_{connection.telegram_chat_id}",
+        "telegram_username": connection.telegram_username,
+        "telegram_connection_id": str(connection.id),
+    }
+
+    if connection.last_active_at:
+        try:
+            context["last_active_at"] = connection.last_active_at.isoformat()
+        except AttributeError:
+            context["last_active_at"] = str(connection.last_active_at)
+
     try:
-        # Convert to lowercase for matching
-        text_lower = message_text.lower()
-        
-        # Simple greeting responses
-        if any(word in text_lower for word in ["hi", "hello", "hey", "good morning", "good evening"]):
-            return "👋 Hello! I'm your CryptoUniverse AI assistant. How can I help you today?\n\nYou can ask about:\n• Trading opportunities\n• Portfolio balance\n• Market analysis\n• Buy/sell crypto\n\nOr use `/help` for all commands."
-        
-        # Check for specific keywords
-        if any(word in text_lower for word in ["opportunities", "opportunity", "recommendations", "suggest"]):
-            return await _handle_opportunities_command(connection, db)
-        
-        if any(word in text_lower for word in ["balance", "portfolio", "worth", "value"]):
-            return await _handle_balance_command(connection, db)
-        
-        if any(word in text_lower for word in ["buy", "purchase"]):
-            return "💡 To buy crypto, use: `/buy BTC 100` (symbol and amount in USD)\n\nExample: `/buy ETH 500` to buy $500 worth of Ethereum."
-        
-        if any(word in text_lower for word in ["sell", "liquidate"]):
-            return "💡 To sell crypto, use: `/sell BTC 100` (symbol and amount in USD)\n\nExample: `/sell BTC 1000` to sell $1000 worth of Bitcoin."
-        
-        if any(word in text_lower for word in ["status", "how am i doing", "performance"]):
-            return await _handle_status_command(connection, db)
-        
-        if any(word in text_lower for word in ["help", "what can you do", "commands"]):
-            return await _handle_help_command(connection.telegram_chat_id, connection.user_id, [])
-        
-        if any(word in text_lower for word in ["ai", "autonomous", "auto trade"]):
-            return "🤖 To control AI trading:\n• `/autonomous start` - Enable AI trading\n• `/autonomous stop` - Disable AI trading\n• `/autonomous status` - Check AI status"
-        
-        if any(word in text_lower for word in ["market", "analysis", "trend"]):
-            return "📊 For market analysis, try:\n• `/market BTC` - Analyze specific asset\n• `/opportunities` - Find trading opportunities\n• `/alerts` - Set price alerts"
-        
-        # Default response with suggestions
-        return """🤔 I'm not sure what you're asking about. Here are some things you can try:
+        ai_result = await unified_ai_manager.process_user_request(
+            user_id=str(connection.user_id),
+            request=message,
+            interface=UnifiedInterfaceType.TELEGRAM,
+            context=context,
+        )
+    except Exception as exc:
+        logger.error(
+            "Unified AI manager failed to handle Telegram message",
+            error=str(exc),
+            user_id=str(connection.user_id),
+        )
+        ai_result = None
 
-📊 **Trading & Analysis:**
-• "Show me opportunities" - Find trading opportunities
-• "What's my balance?" - Check portfolio value
-• "How do I buy Bitcoin?" - Get trading help
+    if ai_result and ai_result.get("success"):
+        action = ai_result.get("action")
+        content = ai_result.get("content")
 
-💬 **Or use commands:**
-• `/opportunities` - Trading opportunities
-• `/portfolio` - Portfolio overview
-• `/help` - All available commands
+        if action == "executed":
+            execution_result = ai_result.get("result", {}) or {}
+            summary_bits: List[str] = []
+            summary = execution_result.get("message") or execution_result.get("status")
+            if summary:
+                summary_bits.append(str(summary))
+            if ai_result.get("ai_analysis"):
+                summary_bits.append(str(ai_result["ai_analysis"]))
+            details = execution_result.get("details")
+            if details:
+                summary_bits.append(str(details))
+            if not summary_bits:
+                summary_bits.append(
+                    "Execution completed. Let me know if you want me to monitor the fill or set follow-up levels."
+                )
+            return " ".join(summary_bits)
 
-What would you like to do?"""
-        
-    except Exception as e:
-        logger.error("Natural language processing failed", error=str(e))
-        return "❌ Sorry, I encountered an error. Please try again or use `/help` for available commands."
+        if content:
+            return str(content)
+
+        if ai_result.get("ai_analysis"):
+            return str(ai_result["ai_analysis"])
+
+        if action == "clarify":
+            return (
+                ai_result.get("content")
+                or "Just to confirm—do you need portfolio context, strategy guidance, or trade execution help?"
+            )
+
+    logger.warning(
+        "Unified AI manager returned no conversational content; falling back to persona-safe default",
+        user_id=str(connection.user_id),
+    )
+
+    return (
+        "I want to make sure I'm pointing you in the right direction. Ask about your holdings, strategy lineup,"
+        " or today's market setups and I'll break it down with the same diligence I'd give on the trading desk."
+    )
 
 
 async def _handle_opportunities_command(connection: UserTelegramConnection, db: AsyncSession) -> str:
@@ -911,57 +915,66 @@ async def _handle_opportunities_command(connection: UserTelegramConnection, db: 
     try:
         # Import the opportunity discovery service
         from app.services.user_opportunity_discovery import user_opportunity_discovery
-        
+
         # Discover opportunities
         opportunities_result = await user_opportunity_discovery.discover_opportunities_for_user(
             user_id=str(connection.user_id),
             force_refresh=True,
             include_strategy_recommendations=True
         )
-        
+
         if not opportunities_result.get("success"):
             return "❌ Failed to fetch opportunities. Please try again."
-        
+
         opportunities = opportunities_result.get("opportunities", [])
         total_count = opportunities_result.get("total_opportunities", 0)
-        
+
         if total_count == 0:
             return "📊 No trading opportunities found at the moment. Markets are being analyzed continuously."
-        
-        # Group opportunities by strategy
-        by_strategy = {}
-        for opp in opportunities[:10]:  # Limit to top 10 for Telegram
-            strategy = opp.get("strategy_name", "Unknown")
-            if strategy not in by_strategy:
-                by_strategy[strategy] = []
-            by_strategy[strategy].append(opp)
-        
-        # Build response
-        response_parts = [f"🎯 **Found {total_count} Trading Opportunities**\n"]
-        
-        for strategy, opps in by_strategy.items():
-            response_parts.append(f"\n**{strategy}** ({len(opps)} opportunities):")
-            
-            if "portfolio" in strategy.lower():
-                # Special handling for portfolio optimization
-                for opp in opps[:3]:
-                    metadata = opp.get("metadata", {})
-                    if metadata.get("strategy_used"):
-                        response_parts.append(f"• {metadata['strategy_used']}: ${opp.get('profit_potential_usd', 0):,.0f} potential")
-                    else:
-                        response_parts.append(f"• {opp.get('symbol', 'N/A')}: {metadata.get('rebalance_action', 'Rebalance')}")
-            else:
-                # Regular opportunities
-                for opp in opps[:3]:
-                    symbol = opp.get("symbol", "N/A")
-                    confidence = opp.get("confidence_score", 0)
-                    profit = opp.get("profit_potential_usd", 0)
-                    response_parts.append(f"• {symbol}: {confidence:.0f}% confidence, ${profit:,.0f} potential")
-        
-        response_parts.append(f"\n💡 Use `/opportunities` for full details or `/trade <symbol>` to execute.")
-        
+        # Prioritize the strongest fits for a balanced profile
+        def _opportunity_rank(opp: Dict[str, Any]) -> float:
+            confidence = float(opp.get("confidence_score", 0))
+            profit = float(opp.get("profit_potential_usd", 0))
+            return confidence * max(profit, 1)
+
+        top_opportunities = sorted(opportunities, key=_opportunity_rank, reverse=True)[:3]
+
+        response_parts = [
+            f"I just reviewed {total_count} live setups. Here are the ones that align best with your balanced risk profile:"  # noqa: E501
+        ]
+
+        for opp in top_opportunities:
+            symbol = opp.get("symbol", "N/A")
+            strategy_name = opp.get("strategy_name", "Strategy")
+            profit = float(opp.get("profit_potential_usd", 0))
+            confidence = float(opp.get("confidence_score", 0))
+            risk_level = (opp.get("risk_level") or "medium").upper()
+            timeframe = opp.get("estimated_timeframe") or opp.get("metadata", {}).get("timeframe")
+            rationale = opp.get("metadata", {}).get("rationale") or opp.get("metadata", {}).get("summary")
+
+            line = (
+                f"• {symbol}: {strategy_name} setup, ~${profit:,.0f} upside with {confidence:.0f}% confidence"
+                f" ({risk_level} risk)"
+            )
+            if timeframe:
+                line += f", targeting {timeframe}"
+            if rationale:
+                line += f". Rationale: {rationale}"
+
+            response_parts.append(line)
+
+        if total_count > len(top_opportunities):
+            response_parts.append(
+                f"I have {total_count - len(top_opportunities)} more opportunities queued."
+                " Ask for a specific symbol or say `Show me more` to drill down."
+            )
+
+        response_parts.append(
+            "Want me to open a trade ticket or compare any of these against your current holdings?"
+        )
+
         return "\n".join(response_parts)
-        
+
     except Exception as e:
         logger.error("Failed to handle opportunities command", error=str(e))
         return "❌ Error fetching opportunities. Please try `/opportunities` command instead."
@@ -972,26 +985,38 @@ async def _handle_status_command(connection: UserTelegramConnection, db: AsyncSe
     try:
         # Get user's portfolio status using your existing service
         from app.api.v1.endpoints.exchanges import get_user_portfolio_from_exchanges
-        
+        from app.models.credit import CreditAccount
+
         portfolio_data = await get_user_portfolio_from_exchanges(str(connection.user_id), db)
-        
+
         if portfolio_data.get("success"):
             total_value = portfolio_data.get("total_value_usd", 0)
             exchange_count = len(portfolio_data.get("exchanges", []))
-            
-            return f"""
-📊 **Account Status**
+            positions = [b for b in portfolio_data.get("balances", []) if b.get("total", 0) > 0]
 
-💰 **Portfolio Value**: ${total_value:,.2f}
-🏦 **Connected Exchanges**: {exchange_count}
-🤖 **AI Status**: Active
-💳 **Credits**: [Loading...]
+            credit_stmt = select(CreditAccount).where(CreditAccount.user_id == connection.user_id)
+            credit_result = await db.execute(credit_stmt)
+            credit_account = credit_result.scalar_one_or_none()
 
-⏰ **Last Updated**: {datetime.utcnow().strftime('%H:%M:%S UTC')}
-"""
+            if credit_account:
+                available_credits = credit_account.available_credits
+                profit_potential = credit_account.total_purchased_credits * 4
+                credit_line = (
+                    f"Credits: {available_credits:,} available (~${profit_potential:,.0f} deployable capital)."
+                )
+            else:
+                credit_line = "Credits: no active balance yet—say `Purchase credits` when you're ready."
+
+            status_lines = [
+                f"Portfolio checks in at ${total_value:,.2f} across {len(positions)} holdings on {exchange_count} exchanges.",
+                credit_line,
+                "AI monitoring is live—I’m watching risk, liquidity, and open orders in the background."
+            ]
+
+            return "\n".join(status_lines)
         else:
             return "❌ Unable to fetch account status. Please check your exchange connections."
-        
+
     except Exception as e:
         logger.error("Status command failed", error=str(e))
         return "❌ Status command failed"
@@ -1002,33 +1027,88 @@ async def _handle_balance_command(connection: UserTelegramConnection, db: AsyncS
     try:
         # Get portfolio balances
         from app.api.v1.endpoints.exchanges import get_user_portfolio_from_exchanges
-        
+
         portfolio_data = await get_user_portfolio_from_exchanges(str(connection.user_id), db)
-        
+
         if portfolio_data.get("success"):
             balances = portfolio_data.get("balances", [])
             total_value = portfolio_data.get("total_value_usd", 0)
-            
-            balance_text = f"💰 **Total Portfolio**: ${total_value:,.2f}\n\n"
-            
-            # Show top 10 balances
-            sorted_balances = sorted(balances, key=lambda x: x.get("value_usd", 0), reverse=True)
-            for balance in sorted_balances[:10]:
-                if balance.get("total", 0) > 0:
-                    asset = balance.get("asset", "")
-                    amount = balance.get("total", 0)
-                    value_usd = balance.get("value_usd", 0)
-                    exchange = balance.get("exchange", "")
-                    
-                    balance_text += f"• **{asset}**: {amount:.6f} (${value_usd:.2f}) [{exchange}]\n"
-            
-            return balance_text
+
+            if total_value <= 0 or not balances:
+                return (
+                    "I’m not seeing any funded positions right now. Once capital lands in the account,"
+                    " I’ll start tracking performance and opportunities automatically."
+                )
+
+            positions = [b for b in balances if b.get("total", 0) > 0]
+
+            # Estimate readily deployable capital
+            available_usd = 0.0
+            for balance in positions:
+                total_units = float(balance.get("total", 0) or 0)
+                free_units = float(balance.get("free", 0) or 0)
+                value_usd = float(balance.get("value_usd", 0) or 0)
+                if total_units > 0 and value_usd:
+                    available_usd += value_usd * (free_units / total_units)
+
+            top_holdings = _summarize_top_holdings(positions, total_value)
+
+            response_lines = [
+                f"Your portfolio is sitting at ${total_value:,.2f} across {len(positions)} active holdings."
+            ]
+
+            if available_usd > 0:
+                response_lines.append(f"Liquid capital ready to deploy: ${available_usd:,.2f}.")
+
+            if top_holdings:
+                response_lines.append("Top positions: " + ", ".join(top_holdings) + ".")
+
+            response_lines.append("Need a closer look at any position or the risk profile? Just let me know.")
+
+            return "\n".join(response_lines)
         else:
             return "❌ Unable to fetch balance. Please check your exchange connections."
-        
+
     except Exception as e:
         logger.error("Balance command failed", error=str(e))
         return "❌ Balance command failed"
+
+
+def _summarize_top_holdings(balances: List[Dict[str, Any]], total_value: float, limit: int = 3) -> List[str]:
+    """Create human-friendly snippets for the largest holdings."""
+
+    if not balances:
+        return []
+
+    safe_total = total_value or sum(float(b.get("value_usd", 0) or 0) for b in balances)
+    if safe_total <= 0:
+        return []
+
+    sorted_balances = sorted(
+        balances,
+        key=lambda b: float(b.get("value_usd", 0) or 0),
+        reverse=True
+    )
+
+    snippets: List[str] = []
+
+    for balance in sorted_balances[:limit]:
+        value_usd = float(balance.get("value_usd", 0) or 0)
+        if value_usd <= 0:
+            continue
+
+        asset = balance.get("asset") or balance.get("symbol") or "Asset"
+        exchange = balance.get("exchange")
+        share = (value_usd / safe_total) * 100
+        share_display = f"{share:.1f}%" if share < 10 else f"{share:.0f}%"
+
+        exchange_label = ""
+        if exchange:
+            exchange_label = f" via {exchange.upper()}"
+
+        snippets.append(f"{asset} ~{share_display} (${value_usd:,.0f}{exchange_label})")
+
+    return snippets
 
 
 async def _handle_buy_command(
@@ -1098,23 +1178,92 @@ async def _handle_credits_command(connection: UserTelegramConnection, db: AsyncS
         
         if credit_account:
             profit_potential = credit_account.total_purchased_credits * 4  # 4x multiplier
-            
-            return f"""
-💳 **Credit Status**
 
-🪙 **Available Credits**: {credit_account.available_credits:,}
-💰 **Profit Potential**: ${profit_potential:,}
-📊 **Total Purchased**: {credit_account.total_purchased_credits:,}
-📈 **Total Used**: {credit_account.total_used_credits:,}
-
-💡 **Need more credits?** Go to dashboard → Credit Center
-"""
+            return (
+                f"You have {credit_account.available_credits:,} credits ready, giving you roughly ${profit_potential:,.0f}"
+                " of deployable trading capacity."
+                f" Lifetime purchased: {credit_account.total_purchased_credits:,}; consumed so far: {credit_account.total_used_credits:,}."
+                " Want me to line up a top-up or allocate credits to a new strategy?"
+            )
         else:
             return "❌ No credit account found. Please purchase credits in the dashboard first."
-        
+
     except Exception as e:
         logger.error("Credits command failed", error=str(e))
         return "❌ Credits command failed"
+
+
+async def _handle_strategy_overview(connection: UserTelegramConnection, db: AsyncSession) -> str:
+    """Provide a natural-language summary of the user's strategy portfolio."""
+
+    try:
+        from app.services.strategy_marketplace_service import strategy_marketplace_service
+
+        portfolio = await strategy_marketplace_service.get_user_strategy_portfolio(str(connection.user_id))
+
+        if not portfolio.get("success"):
+            return (
+                "I'm ready to review your strategy lineup, but the marketplace data is taking a moment to respond."
+                " Let's try again in a few seconds."
+            )
+
+        strategies = portfolio.get("active_strategies", [])
+
+        if not strategies:
+            return (
+                "You're trading in manual mode right now with no automated strategies running."
+                " We can activate Kelly Criterion portfolio optimization, algorithmic pattern recognition,"
+                " or AI-driven futures/options modules whenever you're ready—just say the word."
+            )
+
+        categories = sorted({
+            (strategy.get("category") or "").replace("_", " ").title()
+            for strategy in strategies
+            if strategy.get("category")
+        })
+
+        total_monthly_cost = portfolio.get("total_monthly_cost") or portfolio.get("summary", {}).get("monthly_credit_cost", 0)
+
+        def _strategy_sort_key(item: Dict[str, Any]) -> tuple:
+            win_rate = float(item.get("win_rate", 0) or 0)
+            pnl = float(item.get("total_pnl_usd", 0) or 0)
+            return win_rate, pnl
+
+        highlights = sorted(strategies, key=_strategy_sort_key, reverse=True)[:3]
+
+        response_lines = []
+
+        category_text = ", ".join(categories) if categories else "mixed focus"
+        response_lines.append(
+            f"You have {len(strategies)} automated strategies running right now across {category_text} themes."
+        )
+
+        for strategy in highlights:
+            name = strategy.get("name", "Strategy")
+            risk_level = (strategy.get("risk_level") or "medium").capitalize()
+            win_rate = float(strategy.get("win_rate", 0) or 0)
+            win_rate_display = f"{win_rate * 100:.0f}%" if win_rate else "--"
+            monthly_cost = float(strategy.get("credit_cost_monthly", 0) or 0)
+            pnl = float(strategy.get("total_pnl_usd", 0) or 0)
+            cost_text = "included" if monthly_cost == 0 else f"{monthly_cost:.0f} credits/mo"
+            pnl_text = f"running {pnl:+,.0f} USD" if pnl else "gathering live performance data"
+
+            response_lines.append(
+                f"{name}: {risk_level} risk, win rate {win_rate_display}, {cost_text}, {pnl_text}."
+            )
+
+        if total_monthly_cost:
+            response_lines.append(f"Total monthly credit commitment: {total_monthly_cost:.0f} credits.")
+
+        response_lines.append(
+            "Want me to pause, reallocate, or add another module? Just point me to the strategy you're thinking about."
+        )
+
+        return "\n".join(response_lines)
+
+    except Exception as e:
+        logger.error("Strategy overview failed", error=str(e))
+        return "❌ I couldn't load your strategy lineup just now. Let's try again shortly."
 
 
 def _generate_help_message(connection: UserTelegramConnection) -> str:

--- a/app/api/v1/endpoints/telegram.py
+++ b/app/api/v1/endpoints/telegram.py
@@ -28,13 +28,12 @@ from app.core.database import get_database
 from app.api.v1.endpoints.auth import get_current_user
 from app.models.user import User
 from app.models.telegram_integration import UserTelegramConnection, TelegramMessage
-from app.services.telegram_core import telegram_commander_service
+from app.services.telegram_core import (
+    telegram_commander_service,
+    get_unified_persona_pipeline,
+)
 from app.services.telegram_commander import MessageType
 from app.services.rate_limit import rate_limiter
-from app.services.unified_ai_manager import (
-    unified_ai_manager,
-    InterfaceType as UnifiedInterfaceType,
-)
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -850,11 +849,13 @@ async def _process_natural_language(
         except AttributeError:
             context["last_active_at"] = str(connection.last_active_at)
 
+    unified_ai_manager, unified_interface_type = get_unified_persona_pipeline()
+
     try:
         ai_result = await unified_ai_manager.process_user_request(
             user_id=str(connection.user_id),
             request=message,
-            interface=UnifiedInterfaceType.TELEGRAM,
+            interface=unified_interface_type.TELEGRAM,
             context=context,
         )
     except Exception as exc:

--- a/app/services/ai_manager_startup.py
+++ b/app/services/ai_manager_startup.py
@@ -10,7 +10,7 @@ import structlog
 from app.core.config import get_settings
 from app.services.unified_ai_manager import unified_ai_manager
 from app.services.ai_chat_engine import enhanced_chat_engine as chat_engine
-from app.services.telegram_core import TelegramCommanderService
+from app.services.telegram_core import telegram_commander_service
 from app.services.master_controller import MasterSystemController
 
 settings = get_settings()
@@ -32,7 +32,7 @@ async def initialize_unified_ai_system():
         
         # 3. Connect Telegram to unified manager
         try:
-            telegram_core = TelegramCommanderService()
+            telegram_core = telegram_commander_service
             telegram_core.unified_manager = unified_ai_manager
             logger.info("✅ Telegram connected to unified AI manager")
         except Exception as e:

--- a/app/services/conversation/__init__.py
+++ b/app/services/conversation/__init__.py
@@ -1,0 +1,20 @@
+"""Conversation utilities shared across chat, API, and Telegram interfaces."""
+
+from .persona_middleware import PersonaMiddleware, PersonaProfile
+from .state_hydrator import ConversationStateHydrator, ConversationStateSnapshot, conversation_state_hydrator
+from .response_templates import ResponseTemplates
+from .unified_response_builder import UnifiedResponseBuilder, unified_response_builder
+from .telemetry import ConversationTelemetry, conversation_telemetry
+
+__all__ = [
+    "PersonaMiddleware",
+    "PersonaProfile",
+    "ConversationStateHydrator",
+    "ConversationStateSnapshot",
+    "conversation_state_hydrator",
+    "ResponseTemplates",
+    "UnifiedResponseBuilder",
+    "unified_response_builder",
+    "ConversationTelemetry",
+    "conversation_telemetry",
+]

--- a/app/services/conversation/opportunity_ranker.py
+++ b/app/services/conversation/opportunity_ranker.py
@@ -1,0 +1,194 @@
+"""Utilities to normalize and rank opportunity results across services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+RISK_MAP = {
+    "low": 0.2,
+    "medium": 0.5,
+    "medium-low": 0.4,
+    "medium-high": 0.6,
+    "balanced": 0.5,
+    "moderate": 0.5,
+    "elevated": 0.7,
+    "high": 0.85,
+}
+
+
+@dataclass
+class RankedOpportunity:
+    symbol: str
+    direction: str
+    potential_usd: Optional[float]
+    allocation: Optional[float]
+    win_probability: Optional[float]
+    risk_level: str
+    rationale: Optional[str]
+    score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "direction": self.direction,
+            "potential_usd": self.potential_usd,
+            "allocation": self.allocation,
+            "win_probability": self.win_probability,
+            "risk_level": self.risk_level,
+            "rationale": self.rationale,
+            "score": self.score,
+        }
+
+
+def rank_opportunities(
+    raw_result: Any,
+    *,
+    risk_profile: str,
+    portfolio_value: float,
+    limit: int = 5,
+) -> List[RankedOpportunity]:
+    """Flatten opportunity payloads and score them for conversational output."""
+
+    opportunities = _extract_opportunity_iterable(raw_result)
+    ranked: List[RankedOpportunity] = []
+
+    for item in opportunities:
+        normalized = _normalize_opportunity(item)
+        if not normalized:
+            continue
+
+        risk_penalty = _risk_penalty(normalized["risk_level"], risk_profile)
+        win_probability = normalized.get("win_probability") or 0.0
+        expected_return = normalized.get("expected_return") or 0.0
+        potential_usd = normalized.get("potential_usd")
+
+        # Score emphasizes probability alignment with risk appetite and availability of rationale
+        score = (
+            win_probability * 0.4
+            + expected_return * 0.3
+            + (1.0 - risk_penalty) * 0.2
+            + (0.1 if normalized.get("rationale") else 0.0)
+        )
+
+        ranked.append(
+            RankedOpportunity(
+                symbol=normalized.get("symbol", "UNKNOWN"),
+                direction=normalized.get("direction", ""),
+                potential_usd=potential_usd,
+                allocation=_suggest_allocation(normalized, portfolio_value),
+                win_probability=win_probability,
+                risk_level=normalized.get("risk_level", "unknown"),
+                rationale=normalized.get("rationale"),
+                score=score,
+            )
+        )
+
+    ranked.sort(key=lambda opp: opp.score, reverse=True)
+    return ranked[:limit]
+
+
+def _extract_opportunity_iterable(raw_result: Any) -> Iterable[Dict[str, Any]]:
+    if not raw_result:
+        return []
+
+    if isinstance(raw_result, dict):
+        if "opportunities" in raw_result and isinstance(raw_result["opportunities"], list):
+            return raw_result["opportunities"]
+        # Some services return nested lists keyed by strategy name
+        nested = []
+        for value in raw_result.values():
+            if isinstance(value, list):
+                nested.extend(value)
+            elif isinstance(value, dict) and isinstance(value.get("opportunities"), list):
+                nested.extend(value["opportunities"])
+        return nested
+
+    if isinstance(raw_result, list):
+        return raw_result
+
+    return []
+
+
+def _normalize_opportunity(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not isinstance(item, dict):
+        return None
+
+    symbol = item.get("symbol") or item.get("asset") or item.get("pair")
+    if not symbol:
+        return None
+
+    direction = item.get("direction") or item.get("trade_type") or item.get("action", "")
+    rationale = item.get("rationale") or item.get("reasoning") or item.get("analysis")
+
+    def _coerce_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    potential_usd = _coerce_float(
+        item.get("potential_profit")
+        or item.get("profit_potential")
+        or item.get("potential_usd")
+        or item.get("expected_profit")
+    )
+
+    win_probability = _coerce_float(
+        item.get("win_probability")
+        or item.get("confidence")
+        or item.get("probability")
+    )
+    if win_probability and win_probability > 1:
+        win_probability = win_probability / 100.0
+
+    expected_return = _coerce_float(item.get("expected_return") or item.get("return_pct"))
+    if expected_return and expected_return > 1.5:
+        expected_return = expected_return / 100.0
+
+    risk_level = str(item.get("risk_level") or item.get("risk") or "medium").lower()
+
+    normalized = {
+        "symbol": symbol,
+        "direction": direction,
+        "rationale": rationale,
+        "potential_usd": potential_usd,
+        "expected_return": expected_return or 0.0,
+        "win_probability": win_probability or 0.0,
+        "risk_level": risk_level,
+    }
+
+    allocation = item.get("suggested_allocation") or item.get("allocation_fraction")
+    normalized["allocation_fraction"] = _coerce_float(allocation)
+
+    return normalized
+
+
+def _risk_penalty(opportunity_risk: str, user_risk: str) -> float:
+    opp_score = RISK_MAP.get(opportunity_risk.lower(), 0.6)
+    user_score = RISK_MAP.get(user_risk.lower(), 0.5)
+    return abs(opp_score - user_score)
+
+
+def _suggest_allocation(opportunity: Dict[str, Any], portfolio_value: float) -> Optional[float]:
+    fraction = opportunity.get("allocation_fraction")
+    if fraction is None:
+        # If we have potential profit and expected return, estimate allocation
+        potential = opportunity.get("potential_usd")
+        expected_return = opportunity.get("expected_return")
+        if potential and expected_return:
+            try:
+                base_capital = potential / max(expected_return, 0.01)
+                if portfolio_value > 0:
+                    return min(base_capital / portfolio_value, 1.0)
+            except ZeroDivisionError:
+                return None
+        return None
+
+    try:
+        value = float(fraction)
+        return value if 0 <= value <= 1 else max(0.0, min(value / 100.0, 1.0))
+    except (TypeError, ValueError):
+        return None

--- a/app/services/conversation/persona_middleware.py
+++ b/app/services/conversation/persona_middleware.py
@@ -1,0 +1,116 @@
+"""Persona enforcement utilities for the unified AI money manager."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Any
+import re
+
+
+@dataclass
+class PersonaProfile:
+    """Configuration for the enterprise advisor persona."""
+
+    name: str = "Alex"
+    title: str = "Senior Portfolio Manager"
+    experience_years: int = 15
+    voice_anchor: str = (
+        "I keep your cross-exchange portfolio, credits, and risk posture synchronized in real time."
+    )
+    tone_guidelines: Dict[str, str] = field(
+        default_factory=lambda: {
+            "confidence": "Speak with measured confidence that reflects institutional experience.",
+            "warmth": "Stay approachable and collaborative—sound like a trusted human advisor.",
+            "transparency": "Acknowledge uncertainty or risk explicitly when relevant.",
+        }
+    )
+    closing_prompt: str = "Let me know where you'd like me to focus next."
+    signature: str = "—Alex"
+
+
+class PersonaMiddleware:
+    """Normalize responses so every interface hears the same advisor."""
+
+    bullet_pattern = re.compile(r"^[\-\*•\u2022\u25AA\u25CF]+\s*")
+
+    def __init__(self, profile: Optional[PersonaProfile] = None) -> None:
+        self.profile = profile or PersonaProfile()
+
+    def apply(
+        self,
+        content: str,
+        *,
+        state: Optional[Any] = None,
+        intent: Optional[str] = None,
+        include_intro: bool = False,
+    ) -> str:
+        """Apply persona tone and formatting safeguards to the outgoing message."""
+
+        if not content:
+            return content
+
+        sanitized = self._sanitize_text(content)
+        if not sanitized:
+            return sanitized
+
+        segments = []
+        if include_intro:
+            segments.append(self._build_intro(state))
+
+        segments.append(sanitized)
+
+        enriched = self._append_closing(" ".join(filter(None, segments)))
+        return enriched.strip()
+
+    def _sanitize_text(self, content: str) -> str:
+        """Collapse multi-line templated output into conversational prose."""
+
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        if not lines:
+            return ""
+
+        normalized_lines = []
+        for line in lines:
+            if self.bullet_pattern.match(line):
+                line = self.bullet_pattern.sub("", line)
+            # Strip lingering emojis commonly used as bullets
+            line = re.sub(r"^[\u23FA-\u2BFF\u2600-\u27BF]+\s*", "", line)
+            line = re.sub(r"\s{2,}", " ", line)
+            normalized_lines.append(line.strip())
+
+        # Keep short lists as sentences separated by spaces
+        normalized = " ".join(normalized_lines)
+        normalized = re.sub(r"\s([,.;])", r"\1", normalized)
+        return normalized.strip()
+
+    def _append_closing(self, message: str) -> str:
+        """Ensure the closing reflects the persona voice and invitation."""
+
+        message = message.rstrip()
+        if not message.endswith(('.', '!', '?')):
+            message = f"{message}."
+
+        if self.profile.closing_prompt not in message:
+            message = f"{message} {self.profile.closing_prompt}"
+
+        if self.profile.signature not in message:
+            if not message.endswith(('.', '!', '?')):
+                message = f"{message}."
+            message = f"{message} {self.profile.signature}"
+
+        return re.sub(r"\s{2,}", " ", message).strip()
+
+    def _build_intro(self, state: Optional[Any]) -> str:
+        """Construct an optional intro line referencing current context."""
+
+        intro = f"{self.profile.name} here—your {self.profile.title}."
+        if state and getattr(state, "portfolio", None):
+            total_value = state.portfolio.get("total_value") if isinstance(state.portfolio, dict) else None
+            if total_value:
+                intro += f" Your portfolio is synced at ${float(total_value):,.2f}."
+        intro += f" {self.profile.voice_anchor}"
+        return intro.strip()
+
+
+# Global singleton to avoid re-instantiation across modules
+persona_middleware = PersonaMiddleware()

--- a/app/services/conversation/response_templates.py
+++ b/app/services/conversation/response_templates.py
@@ -1,0 +1,259 @@
+"""Reusable natural-language templates for the unified AI advisor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from app.services.conversation.persona_middleware import PersonaMiddleware, persona_middleware
+from app.services.conversation.opportunity_ranker import rank_opportunities
+from app.services.conversation.state_hydrator import ConversationStateSnapshot
+
+
+@dataclass
+class RenderResult:
+    content: str
+    metadata: Dict[str, Any]
+
+
+class ResponseTemplates:
+    """Craft consistent advisor responses independent of interface."""
+
+    def __init__(self, persona: Optional[PersonaMiddleware] = None) -> None:
+        self.persona = persona or persona_middleware
+
+    def render(
+        self,
+        *,
+        intent: str,
+        request: str,
+        recommendation: Dict[str, Any],
+        service_result: Dict[str, Any],
+        state: ConversationStateSnapshot,
+        ai_analysis: Optional[str] = None,
+        interface: str = "chat",
+        requires_approval: bool = False,
+    ) -> RenderResult:
+        intent_lower = (intent or "").lower()
+
+        if "portfolio" in intent_lower:
+            message, meta = self._portfolio_response(state, service_result, recommendation)
+        elif "strategy" in intent_lower:
+            message, meta = self._strategy_response(state, service_result)
+        elif "credit" in intent_lower:
+            message, meta = self._credit_response(state)
+        elif "opportun" in intent_lower:
+            message, meta = self._opportunity_response(state, service_result, recommendation)
+        elif intent_lower in {"greeting", "help"}:
+            message, meta = self._greeting_response(state)
+        else:
+            message, meta = self._general_response(state, recommendation or {}, ai_analysis, intent_lower)
+
+        if requires_approval:
+            meta["requires_approval"] = True
+
+        enriched = self.persona.apply(message, state=state, intent=intent_lower)
+        return RenderResult(enriched, meta)
+
+    def clarifying_question(
+        self,
+        *,
+        request: str,
+        intent_candidates: Dict[str, float],
+        state: ConversationStateSnapshot,
+    ) -> str:
+        sorted_candidates = sorted(
+            intent_candidates.items(), key=lambda item: item[1], reverse=True
+        )
+        if sorted_candidates:
+            top_candidate = sorted_candidates[0][0].replace("_", " ")
+            alt_candidate = sorted_candidates[1][0].replace("_", " ") if len(sorted_candidates) > 1 else None
+        else:
+            top_candidate, alt_candidate = "portfolio", None
+
+        pieces = [
+            f"I want to make sure I understood your note about '{request}'."
+        ]
+        follow_options: List[str] = []
+        follow_options.append(f"a rundown of your {top_candidate}")
+        if alt_candidate:
+            follow_options.append(f"insight on {alt_candidate}")
+        follow_text = " or ".join(follow_options)
+        pieces.append(f"Are you looking for {follow_text}? If not, let me know what you'd like me to analyze.")
+        return self.persona.apply(" ".join(pieces), state=state, intent="clarifying")
+
+    def _portfolio_response(
+        self,
+        state: ConversationStateSnapshot,
+        service_result: Dict[str, Any],
+        recommendation: Dict[str, Any],
+    ) -> tuple[str, Dict[str, Any]]:
+        portfolio = state.portfolio or {}
+        total_value = state.portfolio_value
+        holdings = state.summarize_holdings()
+        risk = (portfolio.get("risk_level") or state.risk_profile or "balanced").lower()
+        exchanges = portfolio.get("exchanges_connected") or len(portfolio.get("exchanges", []) or [])
+        change = portfolio.get("daily_pnl")
+        change_pct = portfolio.get("daily_pnl_pct")
+
+        lines: List[str] = []
+        if total_value > 0:
+            lines.append(
+                f"Your portfolio is sitting at ${total_value:,.2f} across {exchanges or 'your connected'} exchanges."
+            )
+        if holdings:
+            holding_sentence = ", ".join(
+                f"{symbol} ({pct:.0f}%)" for symbol, pct in holdings
+            )
+            lines.append(
+                f"Top weights are {holding_sentence}—a healthy spread for your {risk} risk posture."
+            )
+        if change is not None and change_pct is not None:
+            lines.append(
+                f"We're {('up' if change >= 0 else 'down')} ${abs(change):,.2f} ({change_pct:.2f}%) on the last 24 hours."
+            )
+        if not lines:
+            lines.append("I don't see live balances yet, so we're in monitoring mode until new data syncs.")
+
+        lines.append("Want me to zoom in on a position or scan for a rebalance?")
+
+        metadata = {
+            "portfolio_value": total_value,
+            "risk_level": risk,
+            "top_positions": holdings,
+        }
+        return " ".join(lines), metadata
+
+    def _strategy_response(
+        self,
+        state: ConversationStateSnapshot,
+        service_result: Dict[str, Any],
+    ) -> tuple[str, Dict[str, Any]]:
+        strategies = state.strategies.active
+        marketplace = state.strategies.marketplace_highlights
+        lines: List[str] = []
+        if strategies:
+            names = [s.get("name") or s.get("strategy_name") for s in strategies[:3]]
+            cleaned_names = ", ".join(filter(None, names))
+            lines.append(
+                f"You're currently in manual mode with {len(strategies)} strategies staged: {cleaned_names}."
+            )
+        else:
+            lines.append("You're not running automated strategies yet—we're in manual guidance mode.")
+
+        if marketplace:
+            categories = {item.get("category", "market") for item in marketplace[:5]}
+            lines.append(
+                "We can activate marketplace models in "
+                + ", ".join(sorted(filter(None, categories)))
+                + " whenever you want."
+            )
+        else:
+            lines.append(
+                "Marketplace access is available if you'd like Kelly optimization, pattern recognition, or derivatives coverage."
+            )
+
+        lines.append("Should I stage a paper run or pull today's best signals from a category?")
+        metadata = {
+            "active_strategy_count": len(strategies),
+            "marketplace_samples": [item.get("name") for item in marketplace[:5]],
+        }
+        return " ".join(lines), metadata
+
+    def _credit_response(self, state: ConversationStateSnapshot) -> tuple[str, Dict[str, Any]]:
+        credit = state.credit
+        available = credit.available_credits
+        profit_potential = credit.profit_potential_usd
+        ratio = credit.credit_to_usd_ratio
+
+        lines: List[str] = []
+        if available > 0:
+            lines.append(
+                f"You have {available} credits live, which unlock about ${profit_potential:,.0f} in profit runway at the current conversion."
+            )
+        else:
+            lines.append("You currently have 0 credits, so we're in analysis mode until you top up.")
+
+        lines.append(
+            "Each credit currently maps to roughly ${:.2f} in commission capacity."
+            .format(ratio)
+        )
+        lines.append("Want me to start a credit upgrade or reallocate toward paper trades instead?")
+
+        metadata = {
+            "available_credits": available,
+            "profit_potential_usd": profit_potential,
+            "credit_to_usd_ratio": ratio,
+            "tier": credit.tier,
+        }
+        return " ".join(lines), metadata
+
+    def _opportunity_response(
+        self,
+        state: ConversationStateSnapshot,
+        service_result: Dict[str, Any],
+        recommendation: Dict[str, Any],
+    ) -> tuple[str, Dict[str, Any]]:
+        ranked = rank_opportunities(
+            service_result or recommendation,
+            risk_profile=state.risk_profile,
+            portfolio_value=state.portfolio_value,
+        )
+
+        lines: List[str] = []
+        if ranked:
+            lines.append(
+                f"I'm tracking {len(ranked)} setups that fit your {state.risk_profile} profile."
+            )
+            highlights = []
+            for idx, opp in enumerate(ranked[:3], start=1):
+                potential_text = (
+                    f"${opp.potential_usd:,.0f}" if opp.potential_usd else "portfolio-aligned"
+                )
+                probability = (
+                    f"{opp.win_probability * 100:.0f}%" if opp.win_probability else "solid"
+                )
+                risk_text = opp.risk_level.replace("_", " ")
+                rationale = opp.rationale or "momentum + structure"
+                highlights.append(
+                    f"{idx}. {opp.symbol} {opp.direction or 'opportunity'} – {potential_text} potential, {probability} probability, {risk_text} risk. Rationale: {rationale}."
+                )
+            lines.append(" ".join(highlights))
+        else:
+            lines.append(
+                "I'm scanning live feeds but don't have a clean setup that matches your risk bands yet. I'll alert you as soon as one clears our filters."
+            )
+
+        lines.append("Do you want me to reserve capital for one of these or widen the search?")
+        metadata = {
+            "ranked_opportunities": [opp.to_dict() for opp in ranked],
+        }
+        return " ".join(lines), metadata
+
+    def _greeting_response(
+        self,
+        state: ConversationStateSnapshot,
+    ) -> tuple[str, Dict[str, Any]]:
+        if state.portfolio_value > 0:
+            message = (
+                f"Welcome back. Your portfolio is synced at ${state.portfolio_value:,.2f}."
+            )
+        else:
+            message = "Welcome back. I'm monitoring your accounts and ready when you are."
+        message += " Ask for your balance, today's opportunities, or tell me what position you want to review."
+        return message, {}
+
+    def _general_response(
+        self,
+        state: ConversationStateSnapshot,
+        recommendation: Dict[str, Any],
+        ai_analysis: Optional[str],
+        intent: str,
+    ) -> tuple[str, Dict[str, Any]]:
+        analysis_text = recommendation.get("analysis") if isinstance(recommendation, dict) else None
+        if not analysis_text:
+            analysis_text = ai_analysis or "I completed the analysis you asked for."
+        message = analysis_text
+        if intent == "general_query" and state.portfolio_value == 0:
+            message += " Let me know if you'd like me to sync balances or walk through strategy options."
+        return message, {"raw_recommendation": recommendation}

--- a/app/services/conversation/state_hydrator.py
+++ b/app/services/conversation/state_hydrator.py
@@ -1,0 +1,190 @@
+"""State hydration helpers that keep portfolio, credit, and strategy data in sync."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import structlog
+
+from app.core.database import AsyncSessionLocal
+from app.services.chat_service_adapters_fixed import chat_adapters_fixed as chat_adapters
+from app.services.credit_ledger import credit_ledger
+from app.services.strategy_marketplace_service import strategy_marketplace_service
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class CreditSnapshot:
+    available_credits: int = 0
+    total_credits: int = 0
+    credit_to_usd_ratio: float = 1.0
+    profit_potential_usd: float = 0.0
+    is_vip: bool = False
+    tier: str = "standard"
+
+
+@dataclass
+class StrategySnapshot:
+    active: List[Dict[str, Any]] = field(default_factory=list)
+    marketplace_highlights: List[Dict[str, Any]] = field(default_factory=list)
+    summary: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ConversationStateSnapshot:
+    """Serializable snapshot of user state for conversational responses."""
+
+    portfolio: Dict[str, Any] = field(default_factory=dict)
+    credit: CreditSnapshot = field(default_factory=CreditSnapshot)
+    strategies: StrategySnapshot = field(default_factory=StrategySnapshot)
+    opportunities: List[Dict[str, Any]] = field(default_factory=list)
+    trading_mode: str = "balanced"
+    risk_profile: str = "balanced"
+    hydrated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["hydrated_at"] = self.hydrated_at.isoformat()
+        return data
+
+    def summarize_holdings(self, limit: int = 3) -> List[Tuple[str, float]]:
+        positions = (self.portfolio or {}).get("positions", [])
+        top_positions = []
+        for position in positions[:limit]:
+            symbol = position.get("symbol") or position.get("asset")
+            pct = float(position.get("percentage") or 0.0)
+            if symbol:
+                top_positions.append((symbol, pct))
+        return top_positions
+
+    @property
+    def portfolio_value(self) -> float:
+        value = (self.portfolio or {}).get("total_value")
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+
+class ConversationStateHydrator:
+    """Fetch the latest portfolio, credit, and strategy state with graceful fallbacks."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+
+    async def hydrate(
+        self,
+        user_id: str,
+        *,
+        intent_hint: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> ConversationStateSnapshot:
+        portfolio_task = asyncio.create_task(self._fetch_portfolio(user_id))
+        credit_task = asyncio.create_task(self._fetch_credit(user_id))
+        strategy_task = asyncio.create_task(self._fetch_strategies(user_id))
+
+        portfolio_result, credit_result, strategy_result = await asyncio.gather(
+            portfolio_task, credit_task, strategy_task, return_exceptions=True
+        )
+
+        snapshot = ConversationStateSnapshot()
+        snapshot.portfolio = self._coerce_portfolio(portfolio_result)
+        snapshot.credit = self._coerce_credit(credit_result)
+        snapshot.strategies = self._coerce_strategies(strategy_result)
+
+        # Derive trading mode / risk profile from strategy metadata when available
+        snapshot.trading_mode = (
+            (context or {}).get("user_config", {}).get("trading_mode")
+            or snapshot.strategies.summary.get("trading_mode")
+            or snapshot.portfolio.get("trading_mode")
+            or "balanced"
+        )
+        snapshot.risk_profile = (
+            (context or {}).get("user_config", {}).get("risk_profile")
+            or snapshot.portfolio.get("risk_level")
+            or snapshot.strategies.summary.get("risk_profile")
+            or "balanced"
+        )
+
+        return snapshot
+
+    async def _fetch_portfolio(self, user_id: str) -> Any:
+        try:
+            return await chat_adapters.get_portfolio_summary(user_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("portfolio_hydration_failed", user_id=user_id, error=str(exc))
+            return {"error": str(exc)}
+
+    async def _fetch_credit(self, user_id: str) -> Any:
+        try:
+            async with AsyncSessionLocal() as db:
+                account = await credit_ledger.get_account(db, user_id, create_if_missing=True)
+                if not account:
+                    return None
+                available = int(account.available_credits or 0)
+                total = int(account.total_credits or 0)
+                ratio = float(account.credit_to_usd_ratio or 1.0)
+                profit_potential = float(account.calculate_profit_potential()) if hasattr(account, "calculate_profit_potential") else 0.0
+                return {
+                    "available": available,
+                    "total": total,
+                    "ratio": ratio,
+                    "profit_potential": profit_potential,
+                    "is_vip": bool(getattr(account, "is_vip", False)),
+                }
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("credit_hydration_failed", user_id=user_id, error=str(exc))
+            return None
+
+    async def _fetch_strategies(self, user_id: str) -> Any:
+        try:
+            return await strategy_marketplace_service.get_user_strategy_portfolio(user_id)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("strategy_hydration_failed", user_id=user_id, error=str(exc))
+            return None
+
+    def _coerce_portfolio(self, portfolio_result: Any) -> Dict[str, Any]:
+        if isinstance(portfolio_result, dict):
+            return portfolio_result
+        return {}
+
+    def _coerce_credit(self, credit_result: Any) -> CreditSnapshot:
+        snapshot = CreditSnapshot()
+        if not isinstance(credit_result, dict):
+            return snapshot
+
+        snapshot.available_credits = int(credit_result.get("available") or 0)
+        snapshot.total_credits = int(credit_result.get("total") or 0)
+        snapshot.credit_to_usd_ratio = float(credit_result.get("ratio") or 1.0)
+        snapshot.profit_potential_usd = float(credit_result.get("profit_potential") or 0.0)
+        snapshot.is_vip = bool(credit_result.get("is_vip"))
+        snapshot.tier = "vip" if snapshot.is_vip else "standard"
+        return snapshot
+
+    def _coerce_strategies(self, strategy_result: Any) -> StrategySnapshot:
+        snapshot = StrategySnapshot()
+        if not isinstance(strategy_result, dict):
+            return snapshot
+
+        snapshot.active = strategy_result.get("active_strategies", []) or []
+        snapshot.marketplace_highlights = strategy_result.get("available_strategies", []) or []
+        summary_fields = {
+            key: strategy_result.get(key)
+            for key in [
+                "total_strategies",
+                "active_strategy_count",
+                "risk_profile",
+                "trading_mode",
+                "recommended_categories",
+            ]
+            if key in strategy_result
+        }
+        snapshot.summary = {k: v for k, v in summary_fields.items() if v is not None}
+        return snapshot
+
+
+conversation_state_hydrator = ConversationStateHydrator()

--- a/app/services/conversation/telemetry.py
+++ b/app/services/conversation/telemetry.py
@@ -1,0 +1,88 @@
+"""Telemetry helpers for unified conversation flows."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Dict
+
+import structlog
+
+from app.core.redis import get_redis_client
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class TelemetryRecord:
+    user_id: str
+    interface: str
+    intent: str
+    request: str
+    confidence: float
+    resolution: Dict[str, Any]
+    state_summary: Dict[str, Any]
+    outcome: str
+    created_at: datetime = datetime.utcnow()
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["created_at"] = self.created_at.isoformat()
+        return payload
+
+
+class ConversationTelemetry:
+    """Persist telemetry for auditing and future tuning."""
+
+    def __init__(self) -> None:
+        self._redis_lock = asyncio.Lock()
+        self._redis = None
+
+    async def record(
+        self,
+        *,
+        user_id: str,
+        interface: str,
+        intent: str,
+        request: str,
+        confidence: float,
+        resolution: Dict[str, Any],
+        state_summary: Dict[str, Any],
+        outcome: str,
+    ) -> None:
+        record = TelemetryRecord(
+            user_id=user_id,
+            interface=interface,
+            intent=intent,
+            request=request,
+            confidence=confidence,
+            resolution=resolution,
+            state_summary=state_summary,
+            outcome=outcome,
+        )
+
+        logger.info("conversation_flow", **record.to_dict())
+
+        redis = await self._get_redis()
+        if redis:
+            key = f"telemetry:conversation:{user_id}"
+            await redis.lpush(key, json.dumps(record.to_dict()))
+            await redis.ltrim(key, 0, 199)
+
+    async def _get_redis(self):
+        if self._redis:
+            return self._redis
+        async with self._redis_lock:
+            if self._redis:
+                return self._redis
+            try:
+                self._redis = await get_redis_client()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.debug("telemetry_redis_unavailable", error=str(exc))
+                self._redis = None
+        return self._redis
+
+
+conversation_telemetry = ConversationTelemetry()

--- a/app/services/conversation/telemetry.py
+++ b/app/services/conversation/telemetry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, Dict
 
@@ -25,7 +25,7 @@ class TelemetryRecord:
     resolution: Dict[str, Any]
     state_summary: Dict[str, Any]
     outcome: str
-    created_at: datetime = datetime.utcnow()
+    created_at: datetime = field(default_factory=datetime.utcnow)
 
     def to_dict(self) -> Dict[str, Any]:
         payload = asdict(self)

--- a/app/services/conversation/unified_response_builder.py
+++ b/app/services/conversation/unified_response_builder.py
@@ -1,0 +1,56 @@
+"""High-level orchestrator that turns decisions into persona-aligned responses."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from app.services.conversation.persona_middleware import PersonaMiddleware, persona_middleware
+from app.services.conversation.response_templates import RenderResult, ResponseTemplates
+from app.services.conversation.state_hydrator import ConversationStateSnapshot
+
+
+class UnifiedResponseBuilder:
+    """Compose final responses using shared templates and persona rules."""
+
+    def __init__(self, persona: Optional[PersonaMiddleware] = None) -> None:
+        self.persona = persona or persona_middleware
+        self.templates = ResponseTemplates(self.persona)
+
+    def build(
+        self,
+        *,
+        intent: str,
+        request: str,
+        recommendation: Dict[str, Any],
+        service_result: Dict[str, Any],
+        state: ConversationStateSnapshot,
+        ai_analysis: Optional[str] = None,
+        interface: str = "chat",
+        requires_approval: bool = False,
+    ) -> RenderResult:
+        return self.templates.render(
+            intent=intent,
+            request=request,
+            recommendation=recommendation,
+            service_result=service_result,
+            state=state,
+            ai_analysis=ai_analysis,
+            interface=interface,
+            requires_approval=requires_approval,
+        )
+
+    def clarify(
+        self,
+        *,
+        request: str,
+        intent_candidates: Dict[str, float],
+        state: ConversationStateSnapshot,
+    ) -> str:
+        return self.templates.clarifying_question(
+            request=request,
+            intent_candidates=intent_candidates,
+            state=state,
+        )
+
+
+unified_response_builder = UnifiedResponseBuilder()

--- a/app/services/conversational_ai_orchestrator.py
+++ b/app/services/conversational_ai_orchestrator.py
@@ -40,7 +40,7 @@ from app.services.trading_strategies import trading_strategies_service
 from app.services.portfolio_risk_core import portfolio_risk_service
 from app.services.market_analysis_core import MarketAnalysisService
 from app.services.ai_consensus_core import AIConsensusService
-from app.services.telegram_core import TelegramCommanderService
+from app.services.telegram_core import telegram_commander_service
 from app.services.chat_memory import ChatMemoryService
 from app.services.user_opportunity_discovery import user_opportunity_discovery
 from app.services.user_onboarding_service import user_onboarding_service
@@ -138,7 +138,13 @@ class ConversationalAIOrchestrator(LoggerMixin):
         self.portfolio_risk = portfolio_risk_service
         self.market_analysis = MarketAnalysisService()
         self.ai_consensus = AIConsensusService()
-        self.telegram_core = TelegramCommanderService()
+        # Reuse the shared Telegram commander so persona, telemetry, and
+        # connection state stay aligned with the unified AI manager across
+        # every interface.
+        self.telegram_core = (
+            getattr(unified_ai_manager, "telegram_core", None)
+            or telegram_commander_service
+        )
         self.memory_service = ChatMemoryService()
         self.opportunity_discovery = user_opportunity_discovery
         self.onboarding_service = user_onboarding_service

--- a/app/services/emergency_manager.py
+++ b/app/services/emergency_manager.py
@@ -539,8 +539,8 @@ class EmergencyManager(LoggerMixin):
             }, user_id)
             
             # Telegram notification
-            from app.services.telegram_core import TelegramCommanderService
-            telegram = TelegramCommanderService()
+            from app.services.telegram_core import telegram_commander_service
+            telegram = telegram_commander_service
             await telegram.send_alert(
                 message_content=f"Emergency action required: {emergency_action}",
                 message_type="alert",

--- a/app/services/telegram_commander.py
+++ b/app/services/telegram_commander.py
@@ -152,31 +152,11 @@ class TelegramConfig:
     WELCOME_MESSAGE = """
 🚀 **CryptoUniverse AI Money Manager**
 
-Welcome to your personal crypto trading assistant! I can help you with:
+I'm Alex, your senior portfolio manager on duty. Ask me for your portfolio balance, today's best opportunities,
+or a deep dive on any position and I'll tailor the answer to your risk profile. When you're ready, I can also
+stage or execute trades directly from here.
 
-📊 **Portfolio Management**
-- Real-time portfolio analysis
-- Risk assessment and optimization
-- Position sizing recommendations
-
-💹 **Trading Operations**
-- Market analysis and opportunities
-- Trade execution across exchanges
-- Strategy recommendations
-
-🤖 **AI Consensus**
-- Multi-AI decision making
-- Confidence-based recommendations
-- Risk-adjusted insights
-
-**Commands:**
-/portfolio - View portfolio summary
-/market - Get market analysis
-/risk - Risk assessment
-/trades - Recent trades
-/help - Full command list
-
-Ready to manage your crypto wealth! 💎
+Need a refresher? Try `/portfolio`, `/opportunities`, or just say "How are we positioned?" to get started.
     """
     
     ERROR_MESSAGES = {

--- a/app/services/telegram_core.py
+++ b/app/services/telegram_core.py
@@ -59,6 +59,12 @@ def _get_unified_persona_pipeline():
 
     return _unified_ai_manager_ref, _unified_interface_type_ref
 
+
+def get_unified_persona_pipeline():
+    """Public accessor for the cached unified persona pipeline references."""
+
+    return _get_unified_persona_pipeline()
+
 settings = get_settings()
 logger = structlog.get_logger(__name__)
 

--- a/app/services/unified_ai_manager.py
+++ b/app/services/unified_ai_manager.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any, Union
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from enum import Enum
 import uuid
 
@@ -27,7 +27,7 @@ from app.services.ai_consensus_core import AIConsensusService
 from app.services.trade_execution import TradeExecutionService
 from app.services.ai_chat_engine import enhanced_chat_engine as chat_engine, ChatIntent
 from app.services.chat_service_adapters_fixed import chat_adapters_fixed as chat_adapters
-from app.services.telegram_core import TelegramCommanderService
+from app.services.telegram_core import TelegramCommanderService, telegram_commander_service
 from app.services.websocket import manager
 from app.services.chat_memory import ChatMemoryService
 
@@ -35,6 +35,13 @@ from app.services.chat_memory import ChatMemoryService
 from app.services.market_analysis_core import MarketAnalysisService
 from app.services.portfolio_risk_core import PortfolioRiskService
 from app.services.trading_strategies import TradingStrategiesService
+from app.services.strategy_marketplace_service import strategy_marketplace_service
+from app.services.conversation import (
+    conversation_state_hydrator,
+    unified_response_builder,
+    conversation_telemetry,
+    ConversationStateSnapshot,
+)
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -75,6 +82,17 @@ class AIDecision:
     context: Dict[str, Any]
 
 
+@dataclass
+class IntentResolution:
+    """Intent classification result with confidence and alternates."""
+
+    intent: str
+    confidence: float
+    candidates: Dict[str, float]
+    raw_intent: Optional[str] = None
+    reason: Optional[str] = None
+
+
 class UnifiedAIManager(LoggerMixin):
     """
     THE UNIFIED AI MONEY MANAGER - Central Brain for All Operations
@@ -89,13 +107,13 @@ class UnifiedAIManager(LoggerMixin):
     - Autonomous mode (fully automated)
     """
     
-    def __init__(self):
+    def __init__(self, telegram_service: Optional[TelegramCommanderService] = None):
         # Core services
         self.master_controller = MasterSystemController()
         self.ai_consensus = AIConsensusService()
         self.trade_executor = TradeExecutionService()
         self.adapters = chat_adapters
-        self.telegram_core = TelegramCommanderService()
+        self.telegram_core = telegram_service or telegram_commander_service
         
         # Enhanced memory service for conversation continuity
         self.memory_service = ChatMemoryService()
@@ -108,11 +126,16 @@ class UnifiedAIManager(LoggerMixin):
         # Redis for state management - initialize properly for async usage
         self.redis = None
         self._redis_initialized = False
-        
+
         # Decision tracking
         self.active_decisions: Dict[str, AIDecision] = {}
         self.user_preferences: Dict[str, Dict[str, Any]] = {}
-        
+
+        # Shared conversational tooling
+        self.state_hydrator = conversation_state_hydrator
+        self.response_builder = unified_response_builder
+        self.telemetry = conversation_telemetry
+
         # Initialize unified brain
         self.logger.info("🧠 UNIFIED AI MONEY MANAGER INITIALIZING")
         self._initialize_unified_brain()
@@ -157,13 +180,49 @@ class UnifiedAIManager(LoggerMixin):
         """
         
         try:
+            context = context or {}
+
             # Get user operation mode and preferences
             user_config = await self._get_user_config(user_id)
             operation_mode = OperationMode(user_config.get("operation_mode", "assisted"))
-            
-            # Classify the request intent
-            intent = await self._classify_unified_intent(request, interface, context)
-            
+
+            state_snapshot = await self.state_hydrator.hydrate(
+                user_id,
+                context={"user_config": user_config, **context},
+            )
+
+            intent_resolution = await self._classify_unified_intent(
+                request, interface, context, state_snapshot
+            )
+            intent = intent_resolution.intent
+
+            # Clarify when we are unsure instead of falling back to canned help
+            if intent_resolution.confidence < 0.55:
+                clarification = self.response_builder.clarify(
+                    request=request,
+                    intent_candidates=intent_resolution.candidates,
+                    state=state_snapshot,
+                )
+                await self.telemetry.record(
+                    user_id=user_id,
+                    interface=interface.value,
+                    intent=intent,
+                    request=request,
+                    confidence=intent_resolution.confidence,
+                    resolution=asdict(intent_resolution),
+                    state_summary=state_snapshot.to_dict(),
+                    outcome="clarify",
+                )
+                return {
+                    "success": True,
+                    "decision_id": None,
+                    "action": "clarify",
+                    "content": clarification,
+                    "requires_approval": False,
+                    "confidence": intent_resolution.confidence,
+                    "metadata": {"intent_candidates": intent_resolution.candidates},
+                }
+
             # Create AI decision context
             decision_context = {
                 "user_id": user_id,
@@ -172,27 +231,34 @@ class UnifiedAIManager(LoggerMixin):
                 "operation_mode": operation_mode.value,
                 "intent": intent,
                 "user_config": user_config,
-                "context": context or {},
-                "timestamp": datetime.utcnow().isoformat()
+                "context": context,
+                "timestamp": datetime.utcnow().isoformat(),
+                "state_snapshot": state_snapshot,
+                "intent_resolution": asdict(intent_resolution),
             }
-            
+
             # ENHANCED: Route to actual services first based on intent
-            service_result = await self._route_to_service(intent, request, user_id, context)
-            
+            service_result = await self._route_to_service(
+                intent, request, user_id, context, state_snapshot
+            )
+            decision_context["service_result"] = service_result
+
             # Then use AI consensus to VALIDATE and format the service result
             enhanced_context = {
-                **decision_context,
+                **{k: v for k, v in decision_context.items() if k != "state_snapshot"},
                 "service_result": service_result,
-                "analysis_type": "validation_and_formatting"
+                "analysis_type": "validation_and_formatting",
             }
-            
+
             ai_response = await self.ai_consensus.analyze_opportunity(
-                json.dumps(enhanced_context),
+                json.dumps(enhanced_context, default=str),
                 confidence_threshold=75.0,
-                ai_models="all", 
-                user_id=user_id
+                ai_models="all",
+                user_id=user_id,
             )
-            
+
+            recommendation_payload = ai_response.get("recommendation", {})
+
             # Create AI decision
             decision = AIDecision(
                 decision_id=str(uuid.uuid4()),
@@ -201,18 +267,20 @@ class UnifiedAIManager(LoggerMixin):
                 operation_mode=operation_mode,
                 intent=intent,
                 decision_type=self._get_decision_type(intent),
-                recommendation=ai_response.get("recommendation", {}),
+                recommendation=recommendation_payload,
                 confidence=ai_response.get("confidence", 0.0),
                 risk_assessment=ai_response.get("risk_assessment", {}),
                 requires_approval=self._requires_approval(operation_mode, intent, ai_response),
                 auto_execute=self._should_auto_execute(operation_mode, intent, ai_response),
                 timestamp=datetime.utcnow(),
-                context=decision_context
+                context=decision_context,
             )
             
+            decision.context["ai_response"] = ai_response
+
             # Store decision
             self.active_decisions[decision.decision_id] = decision
-            
+
             # Execute or return for approval based on operation mode
             if decision.auto_execute and not decision.requires_approval:
                 # Autonomous execution
@@ -228,6 +296,17 @@ class UnifiedAIManager(LoggerMixin):
                         error=execution_result.get("error")
                     )
 
+                await self.telemetry.record(
+                    user_id=user_id,
+                    interface=interface.value,
+                    intent=intent,
+                    request=request,
+                    confidence=decision.confidence,
+                    resolution=asdict(intent_resolution),
+                    state_summary=state_snapshot.to_dict(),
+                    outcome="executed" if execution_result.get("success") else "execution_failed",
+                )
+
                 return {
                     "success": True,
                     "decision_id": decision.decision_id,
@@ -239,6 +318,18 @@ class UnifiedAIManager(LoggerMixin):
             else:
                 # Return for user approval or information
                 formatted_response = await self._format_ai_response(decision, interface)
+
+                await self.telemetry.record(
+                    user_id=user_id,
+                    interface=interface.value,
+                    intent=intent,
+                    request=request,
+                    confidence=decision.confidence,
+                    resolution=asdict(intent_resolution),
+                    state_summary=state_snapshot.to_dict(),
+                    outcome="response",
+                )
+
                 return {
                     "success": True,
                     "decision_id": decision.decision_id,
@@ -915,46 +1006,115 @@ class UnifiedAIManager(LoggerMixin):
                 # Redis write failed, keep in-memory version
                 self.logger.debug(f"Failed to write user config to Redis, keeping in-memory fallback", error=str(e))
     
-    async def _classify_unified_intent(self, request: str, interface: InterfaceType, context: Optional[Dict]) -> str:
-        """Classify intent across all interfaces consistently."""
-        
-        # Use existing chat engine intent classification
-        if hasattr(chat_engine, '_classify_intent'):
-            chat_intent = await chat_engine._classify_intent(request)
-            return chat_intent.value
-        
-        # Fallback classification
-        request_lower = request.lower()
-        
-        if any(word in request_lower for word in ['emergency', 'stop', 'halt', 'panic']):
-            return "emergency_command"
-        elif any(word in request_lower for word in ['buy', 'sell', 'trade', 'execute']):
-            return "trade_execution"
-        elif any(word in request_lower for word in ['portfolio', 'balance', 'holdings']):
-            return "portfolio_analysis"
-        elif any(word in request_lower for word in ['rebalance', 'optimize', 'allocation']):
-            return "rebalancing"
-        elif any(word in request_lower for word in ['risk', 'safety', 'protection']):
-            return "risk_assessment"
-        elif any(word in request_lower for word in ['opportunity', 'find', 'discover']):
-            return "opportunity_discovery"
-        elif any(word in request_lower for word in ['autonomous', 'auto', 'automatic']):
-            return "autonomous_control"
-        else:
-            return "general_query"
+    async def _classify_unified_intent(
+        self,
+        request: str,
+        interface: InterfaceType,
+        context: Optional[Dict],
+        state: Optional[ConversationStateSnapshot] = None,
+    ) -> IntentResolution:
+        """Classify intent across all interfaces with confidence scoring."""
+
+        request_lower = (request or "").lower().strip()
+        candidates: Dict[str, float] = {}
+        raw_intent = None
+
+        # Use existing chat engine intent classification when available
+        if hasattr(chat_engine, "_classify_intent"):
+            try:
+                chat_context = context or {}
+                chat_result = await chat_engine._classify_intent(request, chat_context)  # type: ignore[arg-type]
+            except TypeError:
+                chat_result = await chat_engine._classify_intent(request)
+            raw_intent = getattr(chat_result, "value", str(chat_result))
+
+        keyword_map = {
+            "greeting": ["hi", "hello", "hey", "gm", "good morning", "good evening"],
+            "help": ["help", "what can you do", "how can you help", "commands"],
+            "portfolio_analysis": ["portfolio", "balance", "holdings", "positions", "allocation", "exposure", "value"],
+            "strategy_management": ["strategy", "strategies", "automation", "algo", "bot", "playbook"],
+            "credit_inquiry": ["credit", "credits", "profit potential", "limit", "upgrade", "tier"],
+            "opportunity_discovery": ["opportunity", "opportunities", "signals", "setups", "ideas", "trade idea", "show me opportunities"],
+            "risk_assessment": ["risk", "drawdown", "hedge", "volatility", "stress"],
+            "market_analysis": ["market", "price", "outlook", "btc", "eth", "macro", "analysis"],
+            "trade_execution": ["buy", "sell", "trade", "execute", "allocate", "enter", "exit"],
+            "rebalancing": ["rebalance", "rebalancing", "redistribute", "realign"],
+        }
+
+        for intent_name, keywords in keyword_map.items():
+            match_count = sum(1 for keyword in keywords if keyword in request_lower)
+            if match_count:
+                base_score = 0.45 + 0.1 * (match_count - 1)
+                candidates[intent_name] = min(0.95, base_score)
+
+        if raw_intent:
+            normalized_raw = raw_intent.lower()
+            raw_mapping = {
+                "opportunity_discovery": "opportunity_discovery",
+                "strategy_discussion": "strategy_management",
+                "strategy_recommendation": "strategy_management",
+                "credit_inquiry": "credit_inquiry",
+                "credit_management": "credit_inquiry",
+                "portfolio_analysis": "portfolio_analysis",
+                "market_analysis": "market_analysis",
+                "trade_execution": "trade_execution",
+                "risk_assessment": "risk_assessment",
+                "rebalancing": "rebalancing",
+                "help": "help",
+                "greeting": "greeting",
+            }
+            mapped = raw_mapping.get(normalized_raw, normalized_raw)
+            candidates[mapped] = max(candidates.get(mapped, 0.0), 0.7)
+
+        recent_intents: List[str] = []
+        if context:
+            recent_intents.extend(context.get("previous_intents", []))
+            history = context.get("recent_messages", [])
+            for msg in history:
+                if isinstance(msg, dict) and msg.get("intent"):
+                    recent_intents.append(str(msg["intent"]))
+
+        for prev_intent in recent_intents[-3:]:
+            if prev_intent in candidates:
+                candidates[prev_intent] = max(candidates.get(prev_intent, 0.0), 0.5)
+
+        if not candidates:
+            candidates = {"general_query": 0.35}
+
+        # Emergency overrides
+        if any(word in request_lower for word in ["emergency", "stop", "halt", "panic"]):
+            candidates["emergency_command"] = 0.95
+
+        intent = max(candidates.items(), key=lambda item: item[1])[0]
+        confidence = min(0.99, candidates[intent])
+
+        return IntentResolution(
+            intent=intent,
+            confidence=confidence,
+            candidates=candidates,
+            raw_intent=raw_intent,
+            reason="keyword_match",
+        )
     
     def _get_decision_type(self, intent: str) -> str:
         """Get decision type from intent."""
         mapping = {
             "trade_execution": "trade",
             "portfolio_analysis": "analysis",
+            "market_analysis": "analysis",
             "rebalancing": "rebalance",
             "risk_assessment": "risk_action",
             "opportunity_discovery": "opportunity",
+            "strategy_management": "strategy",
+            "strategy_recommendation": "strategy",
+            "credit_inquiry": "credit",
             "autonomous_control": "mode_change",
-            "emergency_command": "emergency"
+            "emergency_command": "emergency",
+            "general_query": "information",
+            "help": "information",
+            "greeting": "information",
         }
-        return mapping.get(intent, "general")
+        return mapping.get(intent, "information")
     
     def _requires_approval(self, mode: OperationMode, intent: str, ai_response: Dict) -> bool:
         """Determine if decision requires user approval."""
@@ -1107,49 +1267,47 @@ class UnifiedAIManager(LoggerMixin):
     
     async def _format_ai_response(self, decision: AIDecision, interface: InterfaceType) -> Dict[str, Any]:
         """Format AI response based on interface type."""
-        
+
         try:
-            base_content = decision.recommendation.get("analysis", "")
-            
-            if interface == InterfaceType.TELEGRAM:
-                # Telegram formatting (shorter, emoji-rich)
-                content = f"🤖 **AI Analysis**\n\n{base_content[:500]}..."
-                if decision.requires_approval:
-                    content += "\n\nReply 'yes' to execute or 'no' to cancel."
-                    
-            elif interface == InterfaceType.WEB_CHAT:
-                # Web chat formatting (detailed, interactive)
-                content = base_content
-                if decision.requires_approval:
-                    content += "\n\nWould you like me to proceed with this recommendation?"
-                    
-            elif interface == InterfaceType.WEB_UI:
-                # Web UI formatting (structured data)
-                content = {
-                    "analysis": base_content,
-                    "recommendation": decision.recommendation,
-                    "confidence": decision.confidence,
-                    "risk_assessment": decision.risk_assessment
-                }
-                
-            else:
-                content = base_content
-            
-            return {
-                "content": content,
-                "metadata": {
-                    "decision_id": decision.decision_id,
-                    "requires_approval": decision.requires_approval,
-                    "confidence": decision.confidence,
-                    "interface": interface.value,
-                    "intent": decision.intent,
-                    "decision_type": decision.decision_type,
-                    "recommendation": decision.recommendation,
-                    "risk_assessment": decision.risk_assessment,
-                    "timestamp": decision.timestamp.isoformat(),
-                }
+            state_snapshot = decision.context.get("state_snapshot")
+            if not isinstance(state_snapshot, ConversationStateSnapshot):
+                state_snapshot = await self.state_hydrator.hydrate(
+                    decision.user_id,
+                    context=decision.context.get("context") if isinstance(decision.context, dict) else None,
+                )
+
+            service_result = decision.context.get("service_result")
+            if not isinstance(service_result, dict):
+                service_result = {}
+
+            recommendation = decision.recommendation if isinstance(decision.recommendation, dict) else {}
+            ai_response = decision.context.get("ai_response") or {}
+
+            render = self.response_builder.build(
+                intent=decision.intent,
+                request=decision.context.get("request", ""),
+                recommendation=recommendation,
+                service_result=service_result,
+                state=state_snapshot,
+                ai_analysis=ai_response.get("analysis"),
+                interface=interface.value,
+                requires_approval=decision.requires_approval,
+            )
+
+            metadata = {
+                **render.metadata,
+                "decision_id": decision.decision_id,
+                "requires_approval": decision.requires_approval,
+                "confidence": decision.confidence,
+                "interface": interface.value,
+                "intent": decision.intent,
+                "decision_type": decision.decision_type,
+                "risk_assessment": decision.risk_assessment,
+                "timestamp": decision.timestamp.isoformat(),
             }
-            
+
+            return {"content": render.content, "metadata": metadata}
+
         except Exception as e:
             self.logger.error("Response formatting failed", error=str(e))
             return {
@@ -1159,20 +1317,37 @@ class UnifiedAIManager(LoggerMixin):
     
     def _format_for_telegram(self, result: Dict[str, Any]) -> str:
         """Format response specifically for Telegram."""
-        
+
         content = result.get("content", "")
-        confidence = result.get("confidence", 0.0)
-        
-        # Add confidence indicator
-        confidence_emoji = "🟢" if confidence >= 0.9 else "🟡" if confidence >= 0.7 else "🔴"
-        
-        telegram_response = f"{confidence_emoji} **Confidence: {confidence:.1%}**\n\n{content}"
-        
-        # Truncate if too long for Telegram
-        if len(telegram_response) > 4000:
-            telegram_response = telegram_response[:3900] + "\n\n... (truncated)"
-        
-        return telegram_response
+        confidence = result.get("confidence")
+        requires_approval = result.get("requires_approval")
+
+        segments: List[str] = []
+
+        if isinstance(confidence, (int, float)) and confidence > 0:
+            confidence_emoji = "🟢" if confidence >= 0.9 else "🟡" if confidence >= 0.7 else "🔴"
+            segments.append(f"{confidence_emoji} Confidence {confidence * 100:.0f}%")
+
+        if isinstance(content, dict):
+            formatted_content = "\n".join(
+                f"{key.replace('_', ' ').title()}: {value}"
+                for key, value in content.items()
+            )
+        else:
+            formatted_content = str(content).strip()
+
+        if formatted_content:
+            segments.append(formatted_content)
+
+        if requires_approval:
+            segments.append("Ready for me to execute or would you like any tweaks?")
+
+        response = "\n\n".join(segments) if segments else "I processed the request, but there was no additional detail to share."
+
+        if len(response) > 4000:
+            response = response[:3900] + "\n\n... (truncated)"
+
+        return response
     
     async def _notify_all_interfaces(self, user_id: str, notification: Dict[str, Any]):
         """Notify all connected interfaces about important events."""
@@ -1523,12 +1698,19 @@ class UnifiedAIManager(LoggerMixin):
             self.logger.error("Web response enhancement failed", error=str(e))
             return result
     
-    async def _route_to_service(self, intent: str, request: str, user_id: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    async def _route_to_service(
+        self,
+        intent: str,
+        request: str,
+        user_id: str,
+        context: Optional[Dict[str, Any]] = None,
+        state: Optional[ConversationStateSnapshot] = None,
+    ) -> Dict[str, Any]:
         """Route request to appropriate service based on intent - REAL SERVICE CALLS."""
-        
+
         try:
             self.logger.info(f"Routing intent '{intent}' to actual service for user {user_id}")
-            
+
             if "opportunity" in intent.lower() or "discover" in intent.lower():
                 # Route to market analysis for opportunity discovery
                 result = await self.market_analysis.market_inefficiency_scanner(
@@ -1538,12 +1720,27 @@ class UnifiedAIManager(LoggerMixin):
                     user_id=user_id
                 )
                 return {"service": "market_analysis", "method": "opportunity_discovery", "result": result}
-                
+
             elif "portfolio" in intent.lower():
                 # Route to portfolio risk service
                 result = await self.portfolio_risk.get_portfolio_status(user_id)
                 return {"service": "portfolio_risk", "method": "portfolio_analysis", "result": result}
-                
+
+            elif "strategy" in intent.lower():
+                result = await strategy_marketplace_service.get_user_strategy_portfolio(user_id)
+                return {"service": "strategy_marketplace", "method": "strategy_summary", "result": result}
+
+            elif "credit" in intent.lower():
+                credit_state = state.credit if state else None
+                credit_summary = {
+                    "available_credits": getattr(credit_state, "available_credits", None),
+                    "total_credits": getattr(credit_state, "total_credits", None),
+                    "profit_potential_usd": getattr(credit_state, "profit_potential_usd", None),
+                    "credit_to_usd_ratio": getattr(credit_state, "credit_to_usd_ratio", None),
+                    "tier": getattr(credit_state, "tier", "standard"),
+                }
+                return {"service": "credits", "method": "account_summary", "result": credit_summary}
+
             elif "market" in intent.lower() or "analysis" in intent.lower():
                 # Route to market analysis service
                 result = await self.market_analysis.complete_market_assessment(
@@ -1552,12 +1749,26 @@ class UnifiedAIManager(LoggerMixin):
                     user_id=user_id
                 )
                 return {"service": "market_analysis", "method": "market_assessment", "result": result}
-                
+
             elif "trade" in intent.lower() or "buy" in intent.lower() or "sell" in intent.lower():
                 # Route to trading strategies service
                 result = await self.trading_strategies.get_active_strategy(user_id)
                 return {"service": "trading_strategies", "method": "trade_analysis", "result": result}
-                
+
+            elif "rebalance" in intent.lower():
+                result = await self.portfolio_risk.analyze_rebalancing_strategies(
+                    user_id,
+                    risk_profile=(state.risk_profile if state else "medium"),
+                )
+                return {"service": "portfolio_risk", "method": "rebalancing", "result": result}
+
+            elif "risk" in intent.lower():
+                result = await self.portfolio_risk.get_portfolio_status(user_id)
+                return {"service": "portfolio_risk", "method": "risk_assessment", "result": result}
+
+            elif intent.lower() in {"help", "greeting"}:
+                return {"service": "system", "method": "assistant_overview", "result": {"message": "lightweight"}}
+
             else:
                 # Fallback for general queries - no service routing needed
                 return {"service": "none", "method": "general", "result": {"message": "General query - no specific service routing required"}}
@@ -1566,22 +1777,6 @@ class UnifiedAIManager(LoggerMixin):
             self.logger.error(f"Service routing failed for intent '{intent}': {e}")
             return {"service": "error", "method": "fallback", "result": {"error": str(e), "message": "Service routing failed, falling back to AI consensus"}}
 
-    def _get_decision_type(self, intent: str) -> str:
-        """Map intent to decision type."""
-        
-        intent_mapping = {
-            "trade": "trade_execution",
-            "portfolio": "portfolio_management", 
-            "analysis": "market_analysis",
-            "risk": "risk_assessment",
-            "rebalance": "portfolio_rebalance",
-            "autonomous": "mode_change",
-            "emergency": "emergency",
-            "general": "information"
-        }
-        
-        return intent_mapping.get(intent, "general")
-    
     def _requires_approval(
         self, 
         operation_mode: OperationMode, 

--- a/app/services/unified_chat_service.py
+++ b/app/services/unified_chat_service.py
@@ -37,7 +37,7 @@ from app.services.master_controller import MasterSystemController, TradingMode
 from app.services.ai_consensus_core import AIConsensusService
 from app.services.trade_execution import TradeExecutionService
 # Removed chat_service_adapters - unified_chat_service uses direct integrations
-from app.services.telegram_core import TelegramCommanderService
+from app.services.telegram_core import telegram_commander_service
 from app.services.websocket import manager as websocket_manager
 from app.services.chat_memory import ChatMemoryService
 # Note: unified_ai_manager is imported lazily in methods to avoid initialization at module load
@@ -180,7 +180,7 @@ class UnifiedChatService(LoggerMixin):
         self.master_controller = MasterSystemController()
         self.trade_executor = TradeExecutionService()
 # Direct service integrations - no adapters needed
-        self.telegram_core = TelegramCommanderService()
+        self.telegram_core = telegram_commander_service
         self.market_analysis = MarketAnalysisService()
         self.portfolio_risk = PortfolioRiskService()
         self.trading_strategies = TradingStrategiesService()

--- a/tests/services/test_telegram_persona_pipeline.py
+++ b/tests/services/test_telegram_persona_pipeline.py
@@ -11,8 +11,8 @@ os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from app.api.v1.endpoints.telegram import _process_natural_language  # noqa: E402
-from app.services.unified_ai_manager import InterfaceType as UnifiedInterfaceType  # noqa: E402
+from app.api.v1.endpoints.telegram import _process_natural_language
+from app.services.unified_ai_manager import InterfaceType as UnifiedInterfaceType
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_telegram_persona_pipeline.py
+++ b/tests/services/test_telegram_persona_pipeline.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from app.api.v1.endpoints.telegram import _process_natural_language  # noqa: E402
+from app.services.unified_ai_manager import InterfaceType as UnifiedInterfaceType  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_telegram_natural_language_routes_through_unified_manager():
+    connection = SimpleNamespace(
+        user_id="user-123",
+        telegram_chat_id="chat-456",
+        telegram_username="alpha",
+        id="conn-789",
+        last_active_at=None,
+    )
+
+    prompts = [
+        "How can you help me?",
+        "What strategies do I have?",
+        "Show me opportunities today",
+    ]
+
+    persona_responses = [
+        "Here's how I support you day to day: I monitor risk, signal flow, and cash positioning so nothing slips.",
+        "Right now you're running assisted trading with no autonomous strategies deployed—I can line up options whenever you're ready.",
+        "I just reviewed 238 active setups and shortlisted three that align with your balanced profile.",
+    ]
+
+    ai_side_effects = [
+        {"success": True, "action": "recommendation", "content": persona_responses[0], "confidence": 0.91},
+        {"success": True, "action": "recommendation", "content": persona_responses[1], "confidence": 0.87},
+        {"success": True, "action": "recommendation", "content": persona_responses[2], "confidence": 0.9},
+    ]
+
+    with patch(
+        "app.api.v1.endpoints.telegram.unified_ai_manager.process_user_request",
+        AsyncMock(side_effect=ai_side_effects),
+    ) as mocked_manager:
+        outputs = []
+        for prompt in prompts:
+            outputs.append(await _process_natural_language(connection, prompt, None))
+
+    # Ensure the unified manager handled each prompt and produced the persona responses
+    assert outputs == persona_responses
+
+    # Confirm the persona tone remains narrative (no bullet characters) and context was forwarded properly
+    for idx, call in enumerate(mocked_manager.await_args_list):
+        kwargs = call.kwargs
+        assert kwargs["interface"] == UnifiedInterfaceType.TELEGRAM
+        assert kwargs["context"]["chat_id"] == connection.telegram_chat_id
+        assert "•" not in outputs[idx]


### PR DESCRIPTION
## Summary
- route Telegram natural-language handling through the unified AI manager so every chat uses the senior-portfolio-manager persona
- reuse the shared Telegram commander instance when wiring the unified AI manager and startup hooks
- add a regression test that verifies key Telegram prompts receive narrative persona responses

## Testing
- pytest tests/services/test_telegram_persona_pipeline.py
- python -m compileall app/api/v1/endpoints/telegram.py app/services/ai_manager_startup.py app/services/unified_ai_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9480c8888322a68520387ec45ce0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram assistant now speaks with a consistent portfolio‑manager persona and cleaner, natural language replies.
  * State‑aware summaries for portfolio, strategies, credits, and ranked opportunities with rationale and suggested allocation.
  * Richer /status, /balance, /credits and strategy overviews, clarifying questions when intent is unclear, and a concise welcome message.

* **Documentation**
  * Added a comprehensive Telegram chat behavior review with examples and an implementation checklist.

* **Tests**
  * Added tests validating persona tone and unified AI routing in Telegram flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->