### PR TITLE
Add caching orchestrator for opportunity scans

### DIFF
--- a/app/services/chat_service_adapters_fixed.py
+++ b/app/services/chat_service_adapters_fixed.py
@@ -393,7 +393,14 @@ class ChatServiceAdaptersFixed:
             opportunities = []
             
             # Extract opportunities from technical analysis
-            tech_data = tech_analysis.get("data", {})  # Fixed: use "data" not "analysis"
+            tech_data = (
+                tech_analysis.get("analysis")
+                or tech_analysis.get("technical_analysis")
+                or tech_analysis.get("data")
+                or {}
+            )
+            if not isinstance(tech_data, dict):
+                tech_data = {}
             logger.info("Technical analysis data received", symbols=list(tech_data.keys()), data_count=len(tech_data))
             
             for symbol, analysis in tech_data.items():

--- a/app/services/exchange_universe_service.py
+++ b/app/services/exchange_universe_service.py
@@ -1,0 +1,491 @@
+"""Exchange and symbol universe management for market analysis services.
+
+This module centralises how the platform determines which exchanges and
+symbols should be queried for a given user.  It provides a Redis-backed
+cache with an in-memory fallback so request-path code can obtain the
+required universe without blocking on discovery queries.  When user
+context is unavailable the service falls back to platform defaults and a
+volume-ranked symbol list sourced from the existing discovery modules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
+
+from sqlalchemy import select
+
+from app.core.database import AsyncSessionLocal
+from app.core.logging import LoggerMixin
+from app.core.redis import get_redis_client
+from app.models.exchange import ExchangeAccount, ExchangeStatus
+
+EXCHANGE_CACHE_TTL = 300  # 5 minutes
+SYMBOL_CACHE_TTL = 900    # 15 minutes
+
+
+@dataclass
+class _CacheEntry:
+    value: Sequence[str] | Tuple[str, int]
+    expires_at: float
+
+
+class ExchangeUniverseService(LoggerMixin):
+    """Resolve user-scoped exchange and symbol universes with caching."""
+
+    def __init__(self) -> None:
+        self._redis = None
+        self._redis_lock = asyncio.Lock()
+        self._exchange_cache: dict[str, _CacheEntry] = {}
+        self._symbol_cache: dict[str, _CacheEntry] = {}
+        self._user_asset_cache: dict[str, _CacheEntry] = {}
+
+    async def _ensure_redis(self) -> None:
+        if self._redis:
+            return
+        async with self._redis_lock:
+            if self._redis:
+                return
+            try:
+                self._redis = await get_redis_client()
+            except Exception as exc:  # pragma: no cover - optional dependency
+                self.logger.warning("Redis unavailable for exchange universe", error=str(exc))
+                self._redis = None
+
+    async def get_user_exchanges(
+        self,
+        user_id: Optional[str],
+        requested_exchanges: Optional[Iterable[str]] = None,
+        *,
+        default_exchanges: Optional[Sequence[str]] = None,
+    ) -> List[str]:
+        """Return the exchanges that should be queried for the user."""
+
+        normalized_request = self._normalize_list(requested_exchanges)
+        if normalized_request:
+            return normalized_request
+
+        cache_key = f"exchanges:{user_id or 'global'}"
+        cached = await self._get_cached_value(self._exchange_cache, cache_key)
+        if cached is not None:
+            return list(cached)
+
+        exchanges: List[str] = []
+        if user_id:
+            exchanges = await self._load_user_exchanges(user_id)
+
+        if not exchanges:
+            exchanges = list(default_exchanges or [])
+
+        if not exchanges:
+            # Fallback to platform defaults if nothing else is available
+            exchanges = ["binance", "kraken", "kucoin"]
+
+        await self._set_cached_value(self._exchange_cache, cache_key, exchanges, EXCHANGE_CACHE_TTL)
+        await self._store_in_redis(cache_key, exchanges, EXCHANGE_CACHE_TTL)
+        return exchanges
+
+    async def get_symbol_universe(
+        self,
+        user_id: Optional[str],
+        requested_symbols: Optional[Iterable[str]],
+        exchanges: Sequence[str],
+        *,
+        asset_types: Sequence[str] | None = None,
+        limit: Optional[int] = None,
+    ) -> List[str]:
+        """Return the symbol universe for the user and exchanges."""
+
+        normalized_request = self._normalize_list(requested_symbols)
+        if normalized_request:
+            return normalized_request[:limit] if limit else normalized_request
+
+        asset_prefs = await self._get_user_asset_preferences(user_id)
+        effective_limit = limit or (asset_prefs.symbol_limit if asset_prefs else None)
+        min_tier = asset_prefs.max_tier if asset_prefs else "tier_retail"
+
+        key_components = [user_id or "global", ",".join(sorted(exchanges)), min_tier]
+        if asset_types:
+            key_components.append(",".join(sorted(asset_types)))
+        cache_key = "symbols:" + "|".join(key_components)
+
+        cached = await self._get_cached_value(self._symbol_cache, cache_key)
+        if cached is not None:
+            cached_list = list(cached)
+            return cached_list[:effective_limit] if effective_limit else cached_list
+
+        symbols = await self._load_user_symbols(
+            user_id,
+            exchanges,
+            asset_types or ("spot",),
+            min_tier,
+            effective_limit,
+        )
+        if not symbols:
+            symbols = await self._fallback_symbols(effective_limit, min_tier)
+
+        await self._set_cached_value(self._symbol_cache, cache_key, symbols, SYMBOL_CACHE_TTL)
+        await self._store_in_redis(cache_key, symbols, SYMBOL_CACHE_TTL)
+        return symbols
+
+    async def invalidate_user(self, user_id: str) -> None:
+        """Purge cached universes for the supplied user."""
+
+        keys_to_delete = [
+            key
+            for key in list(self._exchange_cache.keys()) + list(self._symbol_cache.keys())
+            if key.startswith(f"exchanges:{user_id}") or key.startswith(f"symbols:{user_id}")
+        ]
+
+        for key in keys_to_delete:
+            self._exchange_cache.pop(key, None)
+            self._symbol_cache.pop(key, None)
+        self._user_asset_cache.pop(f"asset_prefs:{user_id}", None)
+
+        await self._ensure_redis()
+        if self._redis:
+            async with self._redis.pipeline(transaction=False) as pipe:
+                for key in keys_to_delete:
+                    await pipe.delete(key)
+                await pipe.execute()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    async def _load_user_exchanges(self, user_id: str) -> List[str]:
+        """Fetch active exchanges for the user from cache or database."""
+
+        redis_key = f"exchanges:{user_id}"
+        redis_values = await self._read_from_redis(redis_key)
+        if redis_values is not None:
+            return redis_values
+
+        accounts = await self._fetch_exchange_accounts(user_id)
+        exchanges = sorted({acc.exchange_name.lower() for acc in accounts})
+
+        await self._store_in_redis(redis_key, exchanges, EXCHANGE_CACHE_TTL)
+        return exchanges
+
+    async def _load_user_symbols(
+        self,
+        user_id: Optional[str],
+        exchanges: Sequence[str],
+        asset_types: Sequence[str],
+        min_tier: str,
+        limit: Optional[int],
+    ) -> List[str]:
+        redis_key = "symbols:" + "|".join(
+            [
+                user_id or "global",
+                ",".join(sorted(exchanges)),
+                ",".join(sorted(asset_types)),
+                min_tier,
+            ]
+        )
+        redis_values = await self._read_from_redis(redis_key)
+        if redis_values is not None:
+            return redis_values[:limit] if limit else redis_values
+
+        accounts = await self._fetch_exchange_accounts(user_id) if user_id else []
+        symbol_set: set[str] = set()
+        exchanges_lower = {str(exchange).lower() for exchange in exchanges if exchange}
+
+        for account in accounts:
+            if account.exchange_name.lower() not in exchanges_lower:
+                continue
+            allowed = account.allowed_symbols or []
+            for symbol in allowed:
+                if isinstance(symbol, str) and symbol:
+                    symbol_set.add(symbol.upper())
+
+        symbols: List[str] = await self._rank_symbols_by_volume(symbol_set, min_tier, limit)
+
+        if not symbols:
+            symbols = await self._fallback_symbols(limit, min_tier)
+
+        await self._store_in_redis(redis_key, symbols, SYMBOL_CACHE_TTL)
+        return symbols
+
+    async def _fetch_exchange_accounts(self, user_id: Optional[str]) -> List[ExchangeAccount]:
+        if not user_id:
+            return []
+
+        try:
+            user_uuid = uuid.UUID(str(user_id))
+        except (TypeError, ValueError):
+            return []
+
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(ExchangeAccount)
+                .where(ExchangeAccount.user_id == user_uuid)
+                .where(ExchangeAccount.status == ExchangeStatus.ACTIVE)
+                .where(ExchangeAccount.trading_enabled.is_(True))
+            )
+            return list(result.scalars().all())
+
+    async def _fallback_symbols(self, limit: Optional[int], min_tier: str) -> List[str]:
+        """Best-effort discovery for dynamic symbols when user data is absent."""
+
+        try:
+            from app.services.dynamic_asset_filter import enterprise_asset_filter
+
+            if not getattr(enterprise_asset_filter, "session", None):
+                await enterprise_asset_filter.async_init()
+
+            assets = await enterprise_asset_filter.get_top_assets(
+                count=limit or 50,
+                min_tier=min_tier,
+            )
+            symbols = [asset.symbol.upper() for asset in assets if getattr(asset, "symbol", None)]
+            if symbols:
+                return symbols
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self.logger.warning("Enterprise asset filter failed", error=str(exc))
+
+        try:
+            from app.services.simple_asset_discovery import simple_asset_discovery
+
+            await simple_asset_discovery.async_init()
+            symbols = await simple_asset_discovery.get_top_assets(count=limit or 30)
+            if symbols:
+                return [symbol.upper() for symbol in symbols]
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self.logger.warning("Simple asset discovery failed", error=str(exc))
+
+        # Final fallback – if upstream discovery fails return an empty list so
+        # callers can decide how to proceed without introducing hard-coded
+        # assets that may not exist on the user's exchanges.
+        return []
+
+    async def _read_from_redis(self, key: str) -> Optional[List[str]]:
+        await self._ensure_redis()
+        if not self._redis:
+            return None
+
+        try:
+            raw = await self._redis.get(key)
+            if not raw:
+                return None
+
+            if isinstance(raw, (list, tuple)):
+                data: Any = list(raw)
+            elif isinstance(raw, dict):
+                data = raw
+            else:
+                if isinstance(raw, bytes):
+                    raw = raw.decode()
+                if isinstance(raw, str):
+                    data = json.loads(raw)
+                else:
+                    return None
+
+            if isinstance(data, dict):
+                candidates: Iterable[Any]
+                if "symbols" in data:
+                    symbols_value = data["symbols"]
+                    if isinstance(symbols_value, dict):
+                        candidates = symbols_value.keys()
+                    else:
+                        candidates = symbols_value
+                elif "data" in data:
+                    data_value = data["data"]
+                    if isinstance(data_value, dict):
+                        candidates = data_value.keys()
+                    else:
+                        candidates = data_value
+                else:
+                    candidates = data.keys()
+                return self._normalize_cached_symbols(candidates)
+
+            if isinstance(data, (list, tuple, set)):
+                return self._normalize_cached_symbols(data)
+        except Exception as exc:  # pragma: no cover - best effort only
+            self.logger.warning("Failed to read exchange universe cache", error=str(exc))
+        return None
+
+    def _normalize_cached_symbols(self, candidates: Iterable[Any]) -> List[str]:
+        normalized: List[str] = []
+        for item in candidates:
+            value: Any = item
+            if isinstance(value, bytes):
+                try:
+                    value = value.decode()
+                except Exception:  # pragma: no cover - defensive
+                    value = value.decode(errors="ignore") if hasattr(value, "decode") else str(value)
+            if isinstance(value, str):
+                token = value.strip()
+                if token:
+                    normalized.append(token.upper())
+        return normalized
+
+    async def _store_in_redis(self, key: str, values: Sequence[str], ttl: int) -> None:
+        await self._ensure_redis()
+        if not self._redis:
+            return
+        try:
+            await self._redis.setex(key, ttl, json.dumps(list(values)))
+        except Exception as exc:  # pragma: no cover - best effort only
+            self.logger.warning("Failed to persist exchange universe cache", error=str(exc))
+
+    async def _get_cached_value(
+        self,
+        cache: dict[str, _CacheEntry],
+        key: str,
+    ) -> Optional[Sequence[str] | Tuple[str, int]]:
+        entry = cache.get(key)
+        if not entry:
+            return None
+        if entry.expires_at < time.monotonic():
+            cache.pop(key, None)
+            return None
+        return entry.value
+
+    async def _set_cached_value(
+        self,
+        cache: dict[str, _CacheEntry],
+        key: str,
+        values: Sequence[str] | Tuple[str, int],
+        ttl: int,
+    ) -> None:
+        cache[key] = _CacheEntry(value=tuple(values), expires_at=time.monotonic() + ttl)
+
+    def _normalize_list(self, values: Optional[Iterable[str]]) -> List[str]:
+        if not values:
+            return []
+        if isinstance(values, str):
+            values = values.split(",")
+        normalized = []
+        for item in values:
+            if not item:
+                continue
+            normalized.append(str(item).strip())
+        # Preserve order but remove duplicates
+        seen = set()
+        unique = []
+        for item in normalized:
+            if item.lower() in seen:
+                continue
+            seen.add(item.lower())
+            unique.append(item)
+        return unique
+
+    async def _get_asset_filter(self):  # pragma: no cover - exercised via higher level tests
+        try:
+            from app.services.dynamic_asset_filter import enterprise_asset_filter
+
+            if not getattr(enterprise_asset_filter, "session", None):
+                await enterprise_asset_filter.async_init()
+
+            return enterprise_asset_filter
+        except Exception as exc:
+            self.logger.warning("Asset filter unavailable", error=str(exc))
+            return None
+
+    async def _get_user_asset_preferences(self, user_id: Optional[str]) -> Optional["_UserAssetPreferences"]:
+        if not user_id:
+            return None
+
+        cache_key = f"asset_prefs:{user_id}"
+        cached = await self._get_cached_value(self._user_asset_cache, cache_key)
+        if cached is not None:
+            return _UserAssetPreferences(*cached)
+
+        tier_mapping: dict[str, Tuple[str, int]] = {
+            "basic": ("tier_retail", 50),
+            "pro": ("tier_professional", 200),
+            "enterprise": ("tier_institutional", 1000),
+        }
+
+        tier_name = "basic"
+        try:
+            from app.services.strategy_marketplace_service import strategy_marketplace_service
+
+            portfolio = await strategy_marketplace_service.get_user_strategy_portfolio(user_id)
+            if portfolio.get("success"):
+                strategies = portfolio.get("active_strategies", [])
+                total_cost = portfolio.get("total_monthly_cost", 0)
+
+                if len(strategies) >= 10 and total_cost >= 300:
+                    tier_name = "enterprise"
+                elif len(strategies) >= 5 and total_cost >= 100:
+                    tier_name = "pro"
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to determine user asset tier", user_id=user_id, error=str(exc)
+            )
+
+        max_tier, symbol_limit = tier_mapping.get(tier_name, ("tier_retail", 50))
+        prefs = _UserAssetPreferences(max_tier=max_tier, symbol_limit=symbol_limit)
+
+        await self._set_cached_value(
+            self._user_asset_cache,
+            cache_key,
+            (prefs.max_tier, prefs.symbol_limit),
+            SYMBOL_CACHE_TTL,
+        )
+        return prefs
+
+    async def _rank_symbols_by_volume(
+        self,
+        symbols: Iterable[str],
+        min_tier: str,
+        limit: Optional[int],
+    ) -> List[str]:
+        normalized: List[str] = []
+        seen = set()
+        for symbol in symbols:
+            if not symbol:
+                continue
+            upper = str(symbol).upper()
+            if upper in seen:
+                continue
+            seen.add(upper)
+            normalized.append(upper)
+
+        if not normalized:
+            return []
+
+        asset_filter = await self._get_asset_filter()
+        if not asset_filter:
+            return normalized[:limit] if limit else normalized
+
+        try:
+            asset_map = await asset_filter.get_assets_for_symbol_list(normalized)
+        except Exception as exc:
+            self.logger.warning("Symbol ranking failed", error=str(exc))
+            return normalized[:limit] if limit else normalized
+
+        priority_map = {tier.name: tier.priority for tier in asset_filter.VOLUME_TIERS}
+        allowed_priority = priority_map.get(min_tier, priority_map.get("tier_any", 99))
+
+        filtered = [
+            symbol
+            for symbol in normalized
+            if priority_map.get(getattr(asset_map.get(symbol), "tier", "tier_any"), 99)
+            <= allowed_priority
+        ]
+
+        if not filtered:
+            filtered = normalized
+
+        filtered.sort(
+            key=lambda sym: getattr(asset_map.get(sym), "volume_24h_usd", 0),
+            reverse=True,
+        )
+
+        return filtered[:limit] if limit else filtered
+
+
+@dataclass
+class _UserAssetPreferences:
+    max_tier: str
+    symbol_limit: int
+
+
+exchange_universe_service = ExchangeUniverseService()
+

--- a/app/services/market_analysis_core.py
+++ b/app/services/market_analysis_core.py
@@ -29,21 +29,46 @@ Functions migrated:
 """
 
 import asyncio
+import ast
 import copy
+import json
 import os
 import time
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import aiohttp
 import numpy as np
 import pandas as pd
-import aiohttp
 import structlog
 
 from app.core.logging import LoggerMixin
+from app.core.redis import get_redis_client
 from app.services.market_data_feeds import market_data_feeds
+from app.services.exchange_universe_service import exchange_universe_service
 # Avoid circular import - define configurations locally
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class _PriceCacheEntry:
+    data: Dict[str, Any]
+    expires_at: float
+
+
+def _chunked(iterable: Iterable[Any], size: int) -> Iterable[List[Any]]:
+    """Yield fixed-size chunks from an iterable."""
+    chunk: List[Any] = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
 
 
 class ExchangeConfigurations:
@@ -104,16 +129,19 @@ class ExchangeConfigurations:
 
 class DynamicExchangeManager(LoggerMixin):
     """Dynamic Exchange Manager - handles multi-exchange connectivity."""
-    
+
     def __init__(self):
         self.exchange_configs = {
             "kraken": ExchangeConfigurations.KRAKEN,   # Priority 1: Confirmed working
-            "kucoin": ExchangeConfigurations.KUCOIN,   # Priority 2: Confirmed working  
+            "kucoin": ExchangeConfigurations.KUCOIN,   # Priority 2: Confirmed working
             "binance": ExchangeConfigurations.BINANCE  # Priority 3: Now uses binance.us
         }
         self.rate_limiters = {}
         self.circuit_breakers = {}
-        
+        self._sessions: Dict[str, aiohttp.ClientSession] = {}
+        self._session_locks: Dict[int, asyncio.Lock] = {}
+        self._request_timeout = aiohttp.ClientTimeout(total=5)
+
         # Initialize rate limiters for each exchange
         for exchange in self.exchange_configs:
             self.rate_limiters[exchange] = {
@@ -127,22 +155,51 @@ class DynamicExchangeManager(LoggerMixin):
                 "last_failure": None,
                 "success_count": 0
             }
-    
+
+    async def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        loop_id = id(loop)
+        lock = self._session_locks.get(loop_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[loop_id] = lock
+        return lock
+
+    async def _get_session(self, exchange: str) -> aiohttp.ClientSession:
+        lock = await self._get_lock()
+        async with lock:
+            session = self._sessions.get(exchange)
+            if session is None or session.closed:
+                session = aiohttp.ClientSession(timeout=self._request_timeout)
+                self._sessions[exchange] = session
+            return session
+
+    async def close(self) -> None:
+        for session in list(self._sessions.values()):
+            if not session.closed:
+                await session.close()
+        self._sessions.clear()
+
     async def fetch_from_exchange(
-        self, 
-        exchange: str, 
-        endpoint: str, 
+        self,
+        exchange: str,
+        endpoint: str,
         params: Optional[Dict] = None
     ) -> Dict[str, Any]:
         """Fetch data from specific exchange with rate limiting."""
         config = self.exchange_configs[exchange]
         url = config["base_url"] + endpoint
-        
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, params=params, timeout=aiohttp.ClientTimeout(total=10)) as response:
+
+        session = await self._get_session(exchange)
+        try:
+            async with session.get(url, params=params) as response:
                 if response.status != 200:
                     raise Exception(f"{exchange} API error: {response.status}")
                 return await response.json()
+        except asyncio.TimeoutError:
+            raise
+        except Exception:
+            raise
     
     async def get_exchange_health(self) -> Dict[str, Any]:
         """Get health status of all exchanges."""
@@ -170,6 +227,15 @@ class MarketAnalysisService(LoggerMixin):
     ALL SOPHISTICATION PRESERVED - NO SIMPLIFICATION
     """
     
+    EXCHANGE_DEFAULT_QUOTES: Dict[str, str] = {
+        "binance": "USDT",
+        "kucoin": "USDT",
+        "kraken": "USD",
+        "coinbase": "USD",
+        "gateio": "USDT",
+        "bybit": "USDT",
+    }
+
     def __init__(self):
         self.exchange_manager = DynamicExchangeManager()
         self.service_health = {"status": "OPERATIONAL", "last_check": datetime.utcnow()}
@@ -187,6 +253,15 @@ class MarketAnalysisService(LoggerMixin):
             "volatility_analysis": 60,
             "market_overview": 60,
         }
+        self._max_symbol_concurrency = 6
+        self._per_exchange_timeout = 5
+        self._symbol_semaphores: Dict[int, asyncio.Semaphore] = {}
+        self._price_cache: Dict[str, _PriceCacheEntry] = {}
+        self._price_lock_map: Dict[str, asyncio.Lock] = {}
+        self._price_lock_map_lock = asyncio.Lock()
+        self._price_cache_ttl = 30
+        self._redis = None
+        self._redis_lock = asyncio.Lock()
 
     async def _get_cache_lock(self) -> asyncio.Lock:
         """Provide an asyncio lock scoped to the current event loop."""
@@ -229,6 +304,195 @@ class MarketAnalysisService(LoggerMixin):
         })
         return response_copy
 
+    def _build_price_cache_key(self, exchange: str, symbol: str) -> str:
+        symbol_token = symbol.replace("/", "_").upper()
+        return f"price::{exchange.lower()}::{symbol_token}"
+
+    async def _get_price_lock(self, cache_key: str) -> asyncio.Lock:
+        async with self._price_lock_map_lock:
+            lock = self._price_lock_map.get(cache_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._price_lock_map[cache_key] = lock
+            return lock
+
+    async def _ensure_price_redis(self) -> None:
+        if self._redis is not None:
+            return
+        async with self._redis_lock:
+            if self._redis is not None:
+                return
+            try:
+                self._redis = await get_redis_client()
+            except Exception as exc:  # pragma: no cover - optional dependency
+                self.logger.warning(
+                    "Redis unavailable for market analysis price cache",
+                    error=str(exc),
+                )
+                self._redis = None
+
+    def _normalize_symbol_for_exchange(self, exchange: str, symbol: str) -> Tuple[str, str]:
+        exchange_key = (exchange or "").strip().lower() or "binance"
+        if exchange_key in {"auto", "spot", "default"}:
+            exchange_key = "binance"
+
+        token = (symbol or "").strip().upper().replace("-", "/")
+        if not token:
+            return exchange_key, ""
+        if "/" not in token:
+            quote = self.EXCHANGE_DEFAULT_QUOTES.get(exchange_key, "USDT")
+            token = f"{token}/{quote}"
+        return exchange_key, token
+
+    async def _load_price_from_redis(self, cache_key: str) -> Optional[Dict[str, Any]]:
+        await self._ensure_price_redis()
+        if not self._redis:
+            return None
+        try:
+            raw = await self._redis.get(cache_key)
+            if not raw:
+                return None
+
+            payload: Any
+            if isinstance(raw, dict):
+                payload = raw
+            else:
+                if isinstance(raw, bytes):
+                    raw = raw.decode()
+                if isinstance(raw, str):
+                    try:
+                        payload = json.loads(raw)
+                    except (json.JSONDecodeError, TypeError):
+                        try:
+                            payload = ast.literal_eval(str(raw))
+                        except (ValueError, SyntaxError):
+                            return None
+                else:
+                    return None
+
+            if isinstance(payload, dict):
+                candidate = payload.get("data", payload)
+                if isinstance(candidate, dict):
+                    return candidate
+        except Exception as exc:  # pragma: no cover - best effort
+            self.logger.debug("Failed to load price cache from redis", error=str(exc))
+        return None
+
+    async def _store_price_in_redis(
+        self,
+        cache_key: str,
+        data: Dict[str, Any],
+        ttl: int,
+    ) -> None:
+        await self._ensure_price_redis()
+        if not self._redis:
+            return
+        try:
+            payload = json.dumps({"data": data, "timestamp": datetime.utcnow().isoformat()})
+            await self._redis.setex(cache_key, ttl, payload)
+        except Exception as exc:  # pragma: no cover - best effort
+            self.logger.debug("Failed to store price cache", error=str(exc))
+
+    async def get_exchange_price(
+        self,
+        exchange: str,
+        symbol: str,
+        *,
+        ttl: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        exchange_key, normalized_symbol = self._normalize_symbol_for_exchange(exchange, symbol)
+        if not normalized_symbol:
+            return None
+
+        cache_key = self._build_price_cache_key(exchange_key, normalized_symbol)
+        ttl_value = ttl or self._price_cache_ttl
+        now = time.monotonic()
+
+        entry = self._price_cache.get(cache_key)
+        if entry and entry.expires_at > now:
+            return dict(entry.data)
+
+        lock = await self._get_price_lock(cache_key)
+        async with lock:
+            entry = self._price_cache.get(cache_key)
+            if entry and entry.expires_at > now:
+                return dict(entry.data)
+
+            cached = await self._load_price_from_redis(cache_key)
+            if cached:
+                self._price_cache[cache_key] = _PriceCacheEntry(data=cached, expires_at=now + ttl_value)
+                return dict(cached)
+
+            fetched_map = await self._fetch_bulk_symbol_prices(exchange_key, [normalized_symbol])
+            fetched = fetched_map.get(normalized_symbol)
+            if fetched:
+                self._price_cache[cache_key] = _PriceCacheEntry(data=fetched, expires_at=now + ttl_value)
+                await self._store_price_in_redis(cache_key, fetched, ttl_value)
+                return dict(fetched)
+
+            return None
+
+    async def preload_exchange_prices(
+        self,
+        pairs: Sequence[Tuple[str, str]],
+        *,
+        ttl: Optional[int] = None,
+        concurrency: int = 20,
+    ) -> Dict[Tuple[str, str], Optional[Dict[str, Any]]]:
+        if not pairs:
+            return {}
+
+        unique_pairs: Dict[str, List[str]] = defaultdict(list)
+        seen_keys: set[str] = set()
+        for exchange, symbol in pairs:
+            exchange_key, normalized_symbol = self._normalize_symbol_for_exchange(exchange, symbol)
+            if not normalized_symbol:
+                continue
+            cache_key = self._build_price_cache_key(exchange_key, normalized_symbol)
+            if cache_key in seen_keys:
+                continue
+            seen_keys.add(cache_key)
+            unique_pairs[exchange_key].append(normalized_symbol)
+
+        if not unique_pairs:
+            return {}
+
+        semaphore = asyncio.Semaphore(max(1, concurrency))
+        ttl_value = ttl or self._price_cache_ttl
+        results: Dict[Tuple[str, str], Optional[Dict[str, Any]]] = {}
+
+        async def _preload_exchange(exchange_key: str, symbols: Sequence[str]) -> None:
+            async with semaphore:
+                try:
+                    fetched = await self._fetch_bulk_symbol_prices(exchange_key, symbols)
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    self.logger.debug(
+                        "Bulk price preload failed",
+                        exchange=exchange_key,
+                        symbols=len(symbols),
+                        error=str(exc),
+                    )
+                    fetched = {}
+
+                now_inner = time.monotonic()
+                for symbol in symbols:
+                    price = fetched.get(symbol)
+                    cache_key = self._build_price_cache_key(exchange_key, symbol)
+                    if price:
+                        self._price_cache[cache_key] = _PriceCacheEntry(data=price, expires_at=now_inner + ttl_value)
+                        await self._store_price_in_redis(cache_key, price, ttl_value)
+                    results[(exchange_key, symbol)] = price
+
+        tasks = []
+        for exchange_key, symbol_list in unique_pairs.items():
+            chunk_size = max(1, min(100, len(symbol_list)))
+            for chunk in _chunked(symbol_list, chunk_size):
+                tasks.append(_preload_exchange(exchange_key, chunk))
+
+        if tasks:
+            await asyncio.gather(*tasks)
+        return results
+
     async def _get_cached_result(self, cache_key: str) -> Optional[Dict[str, Any]]:
         """Retrieve a cached response if it is still fresh."""
         lock = await self._get_cache_lock()
@@ -262,17 +526,27 @@ class MarketAnalysisService(LoggerMixin):
                 "expires_at": time.monotonic() + ttl_seconds,
             }
 
+    def _get_symbol_semaphore(self) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        loop_id = id(loop)
+        semaphore = self._symbol_semaphores.get(loop_id)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(self._max_symbol_concurrency)
+            self._symbol_semaphores[loop_id] = semaphore
+        return semaphore
+
     async def realtime_price_tracking(
         self,
-        symbols: str,
-        exchanges: str = "all",
+        symbols: Union[str, Sequence[str]],
+        exchanges: Union[str, Sequence[str]] = "all",
         user_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Real-time price tracking across multiple exchanges."""
         start_time = time.time()
 
         try:
-            symbol_list = [s.strip() for s in symbols.split(",") if s.strip()]
+            symbol_list, exchange_list = await self._resolve_universe(symbols, exchanges, user_id)
+
             if not symbol_list:
                 return {
                     "success": True,
@@ -281,19 +555,12 @@ class MarketAnalysisService(LoggerMixin):
                     "metadata": {
                         "symbols_requested": 0,
                         "symbols_found": 0,
-                        "exchanges_checked": 0,
+                        "exchanges_checked": len(exchange_list),
                         "response_time_ms": 0.0,
                         "timestamp": datetime.utcnow().isoformat(),
                         "cache_status": "skip",
                     },
                 }
-
-            exchange_source = (
-                self.exchange_manager.exchange_configs.keys()
-                if exchanges == "all"
-                else [exchanges]
-            )
-            exchange_list = [str(exchange).lower() for exchange in exchange_source]
 
             cache_key = self._build_cache_key(
                 "realtime_price_tracking",
@@ -307,74 +574,15 @@ class MarketAnalysisService(LoggerMixin):
 
             price_data: Dict[str, Any] = {}
 
-            async def fetch_exchange_price(exchange: str, symbol: str):
-                try:
-                    price_info = await self._get_symbol_price(exchange, symbol)
-                    return exchange, price_info
-                except Exception as exc:  # pragma: no cover - defensive logging
-                    self.logger.warning(
-                        "Failed to get symbol price",
-                        symbol=symbol,
-                        exchange=exchange,
-                        error=str(exc),
-                    )
-                    return exchange, None
+            semaphore = self._get_symbol_semaphore()
 
-            for symbol in symbol_list:
-                tasks = [fetch_exchange_price(exchange, symbol) for exchange in exchange_list]
-                results = await asyncio.gather(*tasks, return_exceptions=True)
+            async def process_symbol(symbol: str) -> None:
+                async with semaphore:
+                    symbol_results = await self._collect_symbol_data(symbol, exchange_list)
+                    if symbol_results:
+                        price_data[symbol] = symbol_results
 
-                symbol_data = []
-                for result in results:
-                    if isinstance(result, Exception):  # pragma: no cover - defensive
-                        self.logger.warning(
-                            "Exchange price task failed",
-                            symbol=symbol,
-                            error=str(result),
-                        )
-                        continue
-
-                    exchange, price_info = result
-                    if price_info:
-                        symbol_data.append({"exchange": exchange, **price_info})
-
-                # Get market snapshot from real-time feeds
-                snapshot = await market_data_feeds.get_market_snapshot(symbol, include_onchain=True)
-
-                if symbol_data:
-                    prices = [d["price"] for d in symbol_data]
-                    volumes = [d.get("volume", 0) for d in symbol_data]
-                    min_price = min(prices) if prices else 0
-                    max_price = max(prices) if prices else 0
-                    price_spread = max_price - min_price
-                    spread_percentage = ((max_price - min_price) / min_price) * 100 if min_price > 0 else None
-
-                    price_data[symbol] = {
-                        "exchanges": symbol_data,
-                        "aggregated": {
-                            "average_price": sum(prices) / len(prices),
-                            "price_spread": price_spread,
-                            "spread_percentage": spread_percentage,
-                            "total_volume": sum(volumes),
-                            "exchange_count": len(symbol_data),
-                        },
-                    }
-                elif snapshot.get("success"):
-                    # Use external market data when exchange aggregation fails
-                    price_data[symbol] = {
-                        "exchanges": [],
-                        "aggregated": {
-                            "average_price": snapshot["data"].get("price"),
-                            "price_spread": 0,
-                            "spread_percentage": 0,
-                            "total_volume": snapshot["data"].get("volume_24h", 0),
-                            "exchange_count": 0,
-                        }
-                    }
-
-                if snapshot.get("success"):
-                    price_data.setdefault(symbol, {"exchanges": [], "aggregated": {}})
-                    price_data[symbol]["market_snapshots"] = snapshot["data"]
+            await asyncio.gather(*(process_symbol(symbol) for symbol in symbol_list))
 
             response_time = time.time() - start_time
             await self._update_performance_metrics(response_time, True, user_id)
@@ -399,6 +607,179 @@ class MarketAnalysisService(LoggerMixin):
         except Exception as e:
             await self._update_performance_metrics(time.time() - start_time, False, user_id)
             raise e
+
+    async def _resolve_universe(
+        self,
+        symbols: Union[str, Sequence[str]],
+        exchanges: Union[str, Sequence[str]],
+        user_id: Optional[str],
+    ) -> Tuple[List[str], List[str]]:
+        if isinstance(symbols, str):
+            requested_symbols = [s.strip() for s in symbols.split(",") if s.strip()]
+        else:
+            requested_symbols = [str(s).strip() for s in symbols if str(s).strip()]
+
+        requested_symbols = [token.upper() for token in requested_symbols]
+        if requested_symbols:
+            # Preserve caller ordering while normalizing case and removing duplicates.
+            requested_symbols = list(dict.fromkeys(requested_symbols))
+
+        if isinstance(exchanges, str):
+            exchange_tokens = [e.strip() for e in exchanges.split(",") if e.strip()]
+        else:
+            exchange_tokens = [str(e).strip() for e in exchanges if str(e).strip()]
+
+        if not exchange_tokens or any(token.lower() == "all" for token in exchange_tokens):
+            exchange_tokens = []
+
+        exchange_list = await exchange_universe_service.get_user_exchanges(
+            user_id,
+            exchange_tokens,
+            default_exchanges=self.exchange_manager.exchange_configs.keys(),
+        )
+
+        dynamic_tokens = {"SMART_ADAPTIVE", "DYNAMIC_DISCOVERY", "ALL"}
+        effective_symbols: Optional[Sequence[str]] = None
+        if not requested_symbols or any(token.upper() in dynamic_tokens for token in requested_symbols):
+            requested_symbols = []
+        else:
+            effective_symbols = requested_symbols
+
+        symbol_list = await exchange_universe_service.get_symbol_universe(
+            user_id,
+            effective_symbols,
+            exchange_list,
+        )
+
+        normalized_exchanges = [str(exchange).lower() for exchange in exchange_list]
+
+        return symbol_list, normalized_exchanges
+
+    async def _collect_symbol_data(
+        self,
+        symbol: str,
+        exchange_list: List[str],
+    ) -> Optional[Dict[str, Any]]:
+        async def fetch(exchange: str) -> Optional[Dict[str, Any]]:
+            try:
+                price_info = await asyncio.wait_for(
+                    self._get_symbol_price(exchange, symbol),
+                    timeout=self._per_exchange_timeout,
+                )
+                return {"exchange": exchange, **price_info} if price_info else None
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "Exchange price fetch timed out",
+                    symbol=symbol,
+                    exchange=exchange,
+                    timeout=self._per_exchange_timeout,
+                )
+                return None
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.logger.warning(
+                    "Failed to get symbol price",
+                    symbol=symbol,
+                    exchange=exchange,
+                    error=str(exc),
+                )
+                return None
+
+        tasks = [asyncio.create_task(fetch(exchange)) for exchange in exchange_list]
+
+        exchanges_data: List[Dict[str, Any]] = []
+        try:
+            for task in asyncio.as_completed(tasks):
+                result = await task
+                if result:
+                    exchanges_data.append(result)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+
+        snapshot = await market_data_feeds.get_market_snapshot(symbol, include_onchain=True)
+
+        if exchanges_data:
+            prices = [d["price"] for d in exchanges_data if "price" in d]
+            volumes = [d.get("volume", 0) for d in exchanges_data]
+            min_price = min(prices) if prices else 0
+            max_price = max(prices) if prices else 0
+            spread_percentage = ((max_price - min_price) / min_price) * 100 if min_price > 0 else None
+
+            result = {
+                "exchanges": exchanges_data,
+                "aggregated": {
+                    "average_price": sum(prices) / len(prices) if prices else None,
+                    "price_spread": max_price - min_price if prices else None,
+                    "spread_percentage": spread_percentage,
+                    "total_volume": sum(volumes),
+                    "exchange_count": len(exchanges_data),
+                },
+            }
+        elif snapshot.get("success"):
+            result = {
+                "exchanges": [],
+                "aggregated": {
+                    "average_price": snapshot["data"].get("price"),
+                    "price_spread": 0,
+                    "spread_percentage": 0,
+                    "total_volume": snapshot["data"].get("volume_24h", 0),
+                    "exchange_count": 0,
+                },
+            }
+        else:
+            return None
+
+        if snapshot.get("success"):
+            result.setdefault("market_snapshots", snapshot.get("data", {}))
+
+        return result
+
+    async def _collect_symbol_prices_for_arbitrage(
+        self,
+        symbol: str,
+        exchange_list: List[str],
+    ) -> List[Dict[str, Any]]:
+        async def fetch(exchange: str) -> Optional[Dict[str, Any]]:
+            try:
+                price_info = await asyncio.wait_for(
+                    self._get_symbol_price(exchange, symbol),
+                    timeout=self._per_exchange_timeout,
+                )
+                if price_info:
+                    return {"exchange": exchange, **price_info}
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "Exchange price fetch timed out",
+                    function="cross_exchange_arbitrage_scanner",
+                    symbol=symbol,
+                    exchange=exchange,
+                    timeout=self._per_exchange_timeout,
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.logger.debug(
+                    "Exchange price fetch failed",
+                    function="cross_exchange_arbitrage_scanner",
+                    symbol=symbol,
+                    exchange=exchange,
+                    error=str(exc),
+                )
+            return None
+
+        tasks = [asyncio.create_task(fetch(exchange)) for exchange in exchange_list]
+        results: List[Dict[str, Any]] = []
+
+        try:
+            for task in asyncio.as_completed(tasks):
+                item = await task
+                if item:
+                    results.append(item)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+
+        return results
     
     async def technical_analysis(
         self, 
@@ -756,67 +1137,252 @@ class MarketAnalysisService(LoggerMixin):
     
     # Helper methods (implementation details)
     
-    async def _get_symbol_price(self, exchange: str, symbol: str) -> Optional[Dict[str, Any]]:
-        """Get price for symbol from specific exchange with proper error handling."""
+    async def _fetch_bulk_symbol_prices(
+        self, exchange: str, symbols: Sequence[str]
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        """Fetch prices for a batch of symbols from a single exchange."""
+        if not symbols:
+            return {}
+
+        exchange_key = (exchange or "").strip().lower() or "binance"
+        normalized: List[str] = []
+        for symbol in symbols:
+            _, normalized_symbol = self._normalize_symbol_for_exchange(exchange_key, symbol)
+            if normalized_symbol:
+                normalized.append(normalized_symbol)
+
+        if not normalized:
+            return {}
+
+        try:
+            if exchange_key == "binance":
+                return await self._fetch_binance_bulk(normalized)
+            if exchange_key == "kraken":
+                return await self._fetch_kraken_bulk(normalized)
+            if exchange_key == "kucoin":
+                return await self._fetch_kucoin_bulk(normalized)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self.logger.debug(
+                "Bulk price fetch failed, falling back to single requests",
+                exchange=exchange_key,
+                symbols=len(normalized),
+                error=str(exc),
+            )
+
+        results: Dict[str, Optional[Dict[str, Any]]] = {}
+        for symbol in normalized:
+            try:
+                price = await self._fetch_symbol_price_uncached(exchange_key, symbol)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.logger.debug(
+                    "Single price fetch failed during bulk fallback",
+                    exchange=exchange_key,
+                    symbol=symbol,
+                    error=str(exc),
+                )
+                price = None
+            results[symbol] = price
+        return results
+
+    async def _fetch_binance_bulk(
+        self, symbols: Sequence[str]
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        if not symbols:
+            return {}
+
+        request_symbols = []
+        reverse_map: Dict[str, str] = {}
+        for symbol in symbols:
+            mapped = self._convert_to_binance_symbol(symbol)
+            if not mapped:
+                continue
+            request_symbols.append(mapped)
+            reverse_map[mapped] = symbol
+
+        if not request_symbols:
+            return {}
+
+        params = {"symbols": json.dumps(request_symbols)}
+        data = await self.exchange_manager.fetch_from_exchange(
+            "binance", "/api/v3/ticker/price", params
+        )
+
+        results: Dict[str, Optional[Dict[str, Any]]] = {}
+        payload: Iterable[Dict[str, Any]]
+        if isinstance(data, list):
+            payload = data
+        elif isinstance(data, dict) and "symbol" in data:
+            payload = [data]
+        else:
+            payload = []
+
+        for entry in payload:
+            symbol_code = entry.get("symbol")
+            mapped_symbol = reverse_map.get(symbol_code)
+            if not mapped_symbol:
+                continue
+            price_value = entry.get("price")
+            if price_value is None:
+                continue
+            results[mapped_symbol] = {
+                "price": float(price_value),
+                "volume": 0.0,
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+
+        missing = set(symbols) - set(results.keys())
+        for symbol in missing:
+            results[symbol] = await self._fetch_symbol_price_uncached("binance", symbol)
+
+        return results
+
+    async def _fetch_kraken_bulk(
+        self, symbols: Sequence[str]
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        if not symbols:
+            return {}
+
+        reverse_map: Dict[str, str] = {}
+        pair_tokens: List[str] = []
+        for symbol in symbols:
+            pair = self._convert_to_kraken_symbol(symbol)
+            if not pair:
+                continue
+            reverse_map[pair] = symbol
+            pair_tokens.append(pair)
+
+        if not pair_tokens:
+            return {}
+
+        params = {"pair": ",".join(pair_tokens)}
+        data = await self.exchange_manager.fetch_from_exchange(
+            "kraken", "/0/public/Ticker", params
+        )
+
+        result_payload = data.get("result") if isinstance(data, dict) else None
+        results: Dict[str, Optional[Dict[str, Any]]] = {}
+        if isinstance(result_payload, dict):
+            for pair_code, ticker in result_payload.items():
+                mapped_symbol = reverse_map.get(pair_code)
+                if not mapped_symbol:
+                    continue
+                close_data = None
+                if isinstance(ticker, dict):
+                    close_values = ticker.get("c")
+                    if isinstance(close_values, list) and close_values:
+                        close_data = close_values[0]
+                if close_data is None:
+                    continue
+                results[mapped_symbol] = {
+                    "price": float(close_data),
+                    "volume": 0.0,
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+
+        missing = set(symbols) - set(results.keys())
+        for symbol in missing:
+            results[symbol] = await self._fetch_symbol_price_uncached("kraken", symbol)
+
+        return results
+
+    async def _fetch_kucoin_bulk(
+        self, symbols: Sequence[str]
+    ) -> Dict[str, Optional[Dict[str, Any]]]:
+        if not symbols:
+            return {}
+
+        data = await self.exchange_manager.fetch_from_exchange(
+            "kucoin", "/api/v1/market/allTickers"
+        )
+
+        payload = data.get("data", {}) if isinstance(data, dict) else {}
+        tickers = payload.get("ticker") if isinstance(payload, dict) else None
+        results: Dict[str, Optional[Dict[str, Any]]] = {}
+        if isinstance(tickers, list):
+            reverse_map: Dict[str, str] = {}
+            for symbol in symbols:
+                reverse_map[symbol.replace("/", "-")] = symbol
+
+            for ticker in tickers:
+                if not isinstance(ticker, dict):
+                    continue
+                code = ticker.get("symbol")
+                mapped_symbol = reverse_map.get(code)
+                if not mapped_symbol:
+                    continue
+                last_price = ticker.get("last")
+                if last_price is None:
+                    continue
+                results[mapped_symbol] = {
+                    "price": float(last_price),
+                    "volume": float(ticker.get("vol", 0) or 0),
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+
+        missing = set(symbols) - set(results.keys())
+        for symbol in missing:
+            results[symbol] = await self._fetch_symbol_price_uncached("kucoin", symbol)
+
+        return results
+
+    async def _fetch_symbol_price_uncached(self, exchange: str, symbol: str) -> Optional[Dict[str, Any]]:
+        """Fetch a symbol price from the requested exchange without consulting caches."""
         try:
             if exchange == "binance":
-                # Convert single symbols to USDT trading pairs for Binance
                 binance_symbol = self._convert_to_binance_symbol(symbol)
                 if not binance_symbol:
                     return None
-                    
+
                 try:
                     data = await self.exchange_manager.fetch_from_exchange(
-                        exchange, 
+                        exchange,
                         "/api/v3/ticker/price",
-                        {"symbol": binance_symbol}
+                        {"symbol": binance_symbol},
                     )
                     if data and "price" in data:
                         return {
                             "price": float(data["price"]),
-                            "volume": 0.0,  # Price endpoint doesn't include volume
-                            "timestamp": datetime.utcnow().isoformat()
+                            "volume": 0.0,
+                            "timestamp": datetime.utcnow().isoformat(),
                         }
                 except Exception:
-                    # Fallback to 24hr ticker
                     try:
                         data = await self.exchange_manager.fetch_from_exchange(
-                            exchange, 
+                            exchange,
                             "/api/v3/ticker/24hr",
-                            {"symbol": binance_symbol}
+                            {"symbol": binance_symbol},
                         )
                         if data and "lastPrice" in data:
                             return {
                                 "price": float(data["lastPrice"]),
                                 "volume": float(data.get("volume", 0)),
-                                "timestamp": datetime.utcnow().isoformat()
+                                "timestamp": datetime.utcnow().isoformat(),
                             }
                     except Exception:
-                        pass
-            
+                        return None
+
             elif exchange == "kraken":
                 kraken_symbol = self._convert_to_kraken_symbol(symbol)
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/0/public/Ticker",
-                    {"pair": kraken_symbol}
+                    {"pair": kraken_symbol},
                 )
-                # Check if response has result and the symbol exists
                 if data and "result" in data and kraken_symbol in data["result"]:
                     ticker = data["result"][kraken_symbol]
                     if ticker and "c" in ticker and ticker["c"]:
                         return {
                             "price": float(ticker["c"][0]),
-                            "volume": float(ticker["v"][1]) if "v" in ticker and ticker["v"] else 0.0,
-                            "timestamp": datetime.utcnow().isoformat()
+                            "volume": float(ticker.get("v", [0, 0])[1]) if isinstance(ticker.get("v"), list) else 0.0,
+                            "timestamp": datetime.utcnow().isoformat(),
                         }
-            
+
             elif exchange == "kucoin":
                 kucoin_symbol = symbol.replace("/", "-")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/api/v1/market/stats",
-                    {"symbol": kucoin_symbol}
+                    {"symbol": kucoin_symbol},
                 )
                 if data and "data" in data and data["data"]:
                     market_data = data["data"]
@@ -824,91 +1390,100 @@ class MarketAnalysisService(LoggerMixin):
                     if last_price is not None:
                         return {
                             "price": float(last_price),
-                            "volume": float(market_data.get("vol", 0)) if market_data.get("vol") is not None else 0.0,
-                            "change_24h": float(market_data.get("changeRate", 0)) * 100 if market_data.get("changeRate") is not None else 0.0,
-                            "timestamp": datetime.utcnow().isoformat()
+                            "volume": float(market_data.get("vol", 0) or 0),
+                            "change_24h": float(market_data.get("changeRate", 0) or 0) * 100,
+                            "timestamp": datetime.utcnow().isoformat(),
                         }
-            
+
             elif exchange == "coinbase":
                 coinbase_symbol = symbol.replace("/", "-")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
-                    f"/products/{coinbase_symbol}/ticker"
+                    f"/products/{coinbase_symbol}/ticker",
                 )
-                return {
-                    "price": float(data["price"]),
-                    "volume": float(data["volume"]),
-                    "change_24h": 0,  # Calculate from price and open
-                    "timestamp": datetime.utcnow().isoformat()
-                }
-            
+                if data:
+                    return {
+                        "price": float(data.get("price", 0)),
+                        "volume": float(data.get("volume", 0)),
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+
             elif exchange == "bybit":
                 bybit_symbol = symbol.replace("/", "")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/v5/market/tickers",
-                    {"category": "spot", "symbol": bybit_symbol}
+                    {"category": "spot", "symbol": bybit_symbol},
                 )
-                if data.get("result", {}).get("list"):
-                    ticker = data["result"]["list"][0]
+                listings = data.get("result", {}).get("list") if isinstance(data, dict) else None
+                if listings:
+                    ticker = listings[0]
                     return {
-                        "price": float(ticker["lastPrice"]),
-                        "volume": float(ticker["volume24h"]),
-                        "change_24h": float(ticker["price24hPcnt"]) * 100,
-                        "timestamp": datetime.utcnow().isoformat()
+                        "price": float(ticker.get("lastPrice", 0)),
+                        "volume": float(ticker.get("volume24h", 0)),
+                        "change_24h": float(ticker.get("price24hPcnt", 0)) * 100,
+                        "timestamp": datetime.utcnow().isoformat(),
                     }
-            
+
             elif exchange == "okx":
                 okx_symbol = symbol.replace("/", "-")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/api/v5/market/ticker",
-                    {"instId": okx_symbol}
+                    {"instId": okx_symbol},
                 )
-                if data.get("data"):
+                if isinstance(data, dict) and data.get("data"):
                     ticker = data["data"][0]
                     return {
-                        "price": float(ticker["last"]),
-                        "volume": float(ticker["vol24h"]),
-                        "change_24h": float(ticker["chgPct"]) * 100,
-                        "timestamp": datetime.utcnow().isoformat()
+                        "price": float(ticker.get("last", 0)),
+                        "volume": float(ticker.get("vol24h", 0)),
+                        "change_24h": float(ticker.get("chgPct", 0)) * 100,
+                        "timestamp": datetime.utcnow().isoformat(),
                     }
-            
+
             elif exchange == "bitget":
                 bitget_symbol = symbol.replace("/", "")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/api/spot/v1/market/ticker",
-                    {"symbol": bitget_symbol}
+                    {"symbol": bitget_symbol},
                 )
-                if data.get("data"):
-                    ticker = data["data"]
+                ticker = data.get("data") if isinstance(data, dict) else None
+                if ticker:
                     return {
-                        "price": float(ticker["close"]),
-                        "volume": float(ticker["baseVol"]),
-                        "change_24h": float(ticker["chgRate"]) * 100,
-                        "timestamp": datetime.utcnow().isoformat()
+                        "price": float(ticker.get("close", 0)),
+                        "volume": float(ticker.get("baseVol", 0)),
+                        "change_24h": float(ticker.get("chgRate", 0)) * 100,
+                        "timestamp": datetime.utcnow().isoformat(),
                     }
-            
+
             elif exchange == "gateio":
                 gateio_symbol = symbol.replace("/", "_")
                 data = await self.exchange_manager.fetch_from_exchange(
                     exchange,
                     "/api/v4/spot/tickers",
-                    {"currency_pair": gateio_symbol}
+                    {"currency_pair": gateio_symbol},
                 )
                 if isinstance(data, list) and data:
                     ticker = data[0]
                     return {
-                        "price": float(ticker["last"]),
-                        "volume": float(ticker["base_volume"]),
-                        "change_24h": float(ticker["change_percentage"]),
-                        "timestamp": datetime.utcnow().isoformat()
+                        "price": float(ticker.get("last", 0)),
+                        "volume": float(ticker.get("base_volume", 0)),
+                        "change_24h": float(ticker.get("change_percentage", 0)),
+                        "timestamp": datetime.utcnow().isoformat(),
                     }
-        
-        except Exception as e:
-            self.logger.error(f"Error fetching price for {symbol} from {exchange}: {str(e)}")
-            return None
+
+        except Exception as exc:
+            self.logger.error(
+                "Error fetching price from exchange",
+                exchange=exchange,
+                symbol=symbol,
+                error=str(exc),
+            )
+        return None
+
+    async def _get_symbol_price(self, exchange: str, symbol: str) -> Optional[Dict[str, Any]]:
+        return await self.get_exchange_price(exchange, symbol)
     
     def _convert_to_binance_symbol(self, symbol: str) -> str:
         """Convert standard symbol format to Binance trading pair format."""
@@ -2434,118 +3009,137 @@ class MarketAnalysisService(LoggerMixin):
     
     async def cross_exchange_arbitrage_scanner(
         self,
-        symbols: str = "BTC,ETH,SOL,ADA",
-        exchanges: str = "binance,kraken,kucoin",
+        symbols: Union[str, Sequence[str]] = ("BTC", "ETH", "SOL", "ADA"),
+        exchanges: Union[str, Sequence[str]] = ("binance", "kraken", "kucoin"),
         min_profit_bps: int = 5,
         user_id: str = "system"
     ) -> Dict[str, Any]:
         """ENTERPRISE CROSS-EXCHANGE ARBITRAGE SCANNER - Identify profitable arbitrage opportunities."""
-        
+
         start_time = time.time()
-        
+
         try:
-            await self._update_performance_metrics(time.time() - start_time, True, user_id)
-            
-            symbol_list = [s.strip().upper() for s in symbols.split(",")]
-            exchange_list = [e.strip().lower() for e in exchanges.split(",")]
-            
-            opportunities = []
-            total_scanned = 0
-            
-            # Scan each symbol across all exchanges
-            for symbol in symbol_list:
-                prices = {}
-                
-                # Get prices from all exchanges
-                for exchange in exchange_list:
-                    try:
-                        price_data = await self._get_symbol_price(exchange, symbol)
-                        if price_data and price_data.get("price"):
-                            prices[exchange] = {
-                                "price": float(price_data["price"]),
-                                "volume": float(price_data.get("volume", 0)),
-                                "timestamp": price_data.get("timestamp", datetime.utcnow().isoformat())
-                            }
-                    except Exception as e:
-                        self.logger.debug(f"Failed to get {symbol} price from {exchange}: {str(e)}")
-                        continue
-                
-                total_scanned += len(exchange_list)
-                
-                # Find arbitrage opportunities
-                if len(prices) >= 2:
-                    price_items = list(prices.items())
-                    
-                    for i in range(len(price_items)):
-                        for j in range(i + 1, len(price_items)):
-                            buy_exchange, buy_data = price_items[i]
-                            sell_exchange, sell_data = price_items[j]
-                            
-                            # Calculate profit for both directions
-                            profit_direction_1 = (sell_data["price"] - buy_data["price"]) / buy_data["price"] * 10000
-                            profit_direction_2 = (buy_data["price"] - sell_data["price"]) / sell_data["price"] * 10000
-                            
-                            # Check if profit exceeds minimum threshold
-                            if profit_direction_1 >= min_profit_bps:
-                                opportunities.append({
-                                    "id": f"{symbol}_{buy_exchange}_{sell_exchange}_{int(time.time())}",
-                                    "symbol": symbol,
-                                    "buy_exchange": buy_exchange,
-                                    "sell_exchange": sell_exchange,
-                                    "buy_price": buy_data["price"],
-                                    "sell_price": sell_data["price"],
-                                    "profit_bps": round(profit_direction_1, 2),
-                                    "profit_percentage": round(profit_direction_1 / 100, 4),
-                                    "min_volume": min(buy_data["volume"], sell_data["volume"]),
-                                    "confidence": min(85.0, 60.0 + (profit_direction_1 / 10)),
-                                    "risk_score": max(1, 10 - (profit_direction_1 / 2)),
-                                    "timestamp": datetime.utcnow().isoformat()
-                                })
-                            
-                            elif profit_direction_2 >= min_profit_bps:
-                                opportunities.append({
-                                    "id": f"{symbol}_{sell_exchange}_{buy_exchange}_{int(time.time())}",
-                                    "symbol": symbol,
-                                    "buy_exchange": sell_exchange,
-                                    "sell_exchange": buy_exchange,
-                                    "buy_price": sell_data["price"],
-                                    "sell_price": buy_data["price"],
-                                    "profit_bps": round(profit_direction_2, 2),
-                                    "profit_percentage": round(profit_direction_2 / 100, 4),
-                                    "min_volume": min(buy_data["volume"], sell_data["volume"]),
-                                    "confidence": min(85.0, 60.0 + (profit_direction_2 / 10)),
-                                    "risk_score": max(1, 10 - (profit_direction_2 / 2)),
-                                    "timestamp": datetime.utcnow().isoformat()
-                                })
-            
-            # Sort opportunities by profit (descending)
+            symbol_list, exchange_list = await self._resolve_universe(symbols, exchanges, user_id)
+
+            if len(exchange_list) < 2:
+                response_time = time.time() - start_time
+                await self._update_performance_metrics(response_time, True, user_id)
+                return {
+                    "success": True,
+                    "data": {
+                        "opportunities": [],
+                        "summary": {
+                            "total_opportunities": 0,
+                            "symbols_scanned": len(symbol_list),
+                            "exchanges_scanned": len(exchange_list),
+                            "pairs_analyzed": 0,
+                            "min_profit_threshold": min_profit_bps,
+                            "max_profit_found": 0,
+                            "avg_confidence": 0,
+                        },
+                        "metadata": {
+                            "scan_timestamp": datetime.utcnow().isoformat(),
+                            "response_time_ms": round(response_time * 1000, 2),
+                            "user_id": user_id,
+                            "scan_type": "cross_exchange_arbitrage",
+                            "insufficient_exchanges": True,
+                        },
+                    },
+                }
+
+            semaphore = self._get_symbol_semaphore()
+            opportunities: List[Dict[str, Any]] = []
+            total_quotes = 0
+
+            async def analyze_symbol(symbol: str) -> Tuple[str, List[Dict[str, Any]]]:
+                async with semaphore:
+                    prices = await self._collect_symbol_prices_for_arbitrage(symbol, exchange_list)
+                return symbol, prices
+
+            symbol_results = await asyncio.gather(
+                *(analyze_symbol(symbol) for symbol in symbol_list)
+            )
+
+            for symbol, prices in symbol_results:
+                total_quotes += len(prices)
+                if len(prices) < 2:
+                    continue
+
+                for i in range(len(prices)):
+                    for j in range(i + 1, len(prices)):
+                        buy_data = prices[i]
+                        sell_data = prices[j]
+
+                        profit_direction_1 = (sell_data["price"] - buy_data["price"]) / buy_data["price"] * 10000
+                        profit_direction_2 = (buy_data["price"] - sell_data["price"]) / sell_data["price"] * 10000
+
+                        if profit_direction_1 >= min_profit_bps:
+                            opportunities.append({
+                                "id": f"{symbol}_{buy_data['exchange']}_{sell_data['exchange']}_{int(time.time())}",
+                                "symbol": symbol,
+                                "buy_exchange": buy_data["exchange"],
+                                "sell_exchange": sell_data["exchange"],
+                                "buy_price": buy_data["price"],
+                                "sell_price": sell_data["price"],
+                                "profit_bps": round(profit_direction_1, 2),
+                                "profit_percentage": round(profit_direction_1 / 100, 4),
+                                "min_volume": min(buy_data.get("volume", 0), sell_data.get("volume", 0)),
+                                "confidence": min(85.0, 60.0 + (profit_direction_1 / 10)),
+                                "risk_score": max(1, 10 - (profit_direction_1 / 2)),
+                                "timestamp": datetime.utcnow().isoformat(),
+                            })
+
+                        elif profit_direction_2 >= min_profit_bps:
+                            opportunities.append({
+                                "id": f"{symbol}_{sell_data['exchange']}_{buy_data['exchange']}_{int(time.time())}",
+                                "symbol": symbol,
+                                "buy_exchange": sell_data["exchange"],
+                                "sell_exchange": buy_data["exchange"],
+                                "buy_price": sell_data["price"],
+                                "sell_price": buy_data["price"],
+                                "profit_bps": round(profit_direction_2, 2),
+                                "profit_percentage": round(profit_direction_2 / 100, 4),
+                                "min_volume": min(buy_data.get("volume", 0), sell_data.get("volume", 0)),
+                                "confidence": min(85.0, 60.0 + (profit_direction_2 / 10)),
+                                "risk_score": max(1, 10 - (profit_direction_2 / 2)),
+                                "timestamp": datetime.utcnow().isoformat(),
+                            })
+
             opportunities.sort(key=lambda x: x["profit_bps"], reverse=True)
-            
+
             response_time = time.time() - start_time
             await self._update_performance_metrics(response_time, True, user_id)
-            
+
+            summary = {
+                "total_opportunities": len(opportunities),
+                "symbols_scanned": len(symbol_list),
+                "exchanges_scanned": len(exchange_list),
+                "pairs_analyzed": total_quotes,
+                "min_profit_threshold": min_profit_bps,
+                "max_profit_found": max((opp["profit_bps"] for opp in opportunities), default=0),
+                "avg_confidence": round(
+                    sum(opp["confidence"] for opp in opportunities) / len(opportunities), 2
+                ) if opportunities else 0,
+            }
+
+            metadata = {
+                "scan_timestamp": datetime.utcnow().isoformat(),
+                "response_time_ms": round(response_time * 1000, 2),
+                "user_id": user_id,
+                "scan_type": "cross_exchange_arbitrage",
+                "symbols": symbol_list,
+                "exchanges": exchange_list,
+            }
+
             return {
                 "success": True,
                 "data": {
                     "opportunities": opportunities,
-                    "summary": {
-                        "total_opportunities": len(opportunities),
-                        "symbols_scanned": len(symbol_list),
-                        "exchanges_scanned": len(exchange_list),
-                        "pairs_analyzed": total_scanned,
-                        "min_profit_threshold": min_profit_bps,
-                        "max_profit_found": max([opp["profit_bps"] for opp in opportunities]) if opportunities else 0,
-                        "avg_confidence": round(sum([opp["confidence"] for opp in opportunities]) / len(opportunities), 2) if opportunities else 0
-                    },
-                    "metadata": {
-                        "scan_timestamp": datetime.utcnow().isoformat(),
-                        "response_time_ms": round(response_time * 1000, 2),
-                        "user_id": user_id,
-                        "scan_type": "cross_exchange_arbitrage"
-                    }
-                }
+                    "summary": summary,
+                    "metadata": metadata,
+                },
             }
-            
+
         except Exception as e:
             await self._update_performance_metrics(time.time() - start_time, False, user_id)
             self.logger.error("Cross-exchange arbitrage scan failed", error=str(e), exc_info=True)
@@ -2553,8 +3147,8 @@ class MarketAnalysisService(LoggerMixin):
     
     async def market_inefficiency_scanner(
         self,
-        symbols: str,
-        exchanges: str = "all",
+        symbols: Union[str, Sequence[str]],
+        exchanges: Union[str, Sequence[str]] = "all",
         scan_types: str = "spread,volume,time",
         user_id: str = "system"
     ) -> Dict[str, Any]:
@@ -2563,11 +3157,8 @@ class MarketAnalysisService(LoggerMixin):
         start_time = time.time()
         
         try:
-            symbol_list = [s.strip().upper() for s in symbols.split(",")]
-            exchange_list = [e.strip().lower() for e in exchanges.split(",")]
-            if "all" in exchange_list:
-                exchange_list = ["binance", "kraken", "kucoin", "coinbase", "bybit"]
-            
+            symbol_list, exchange_list = await self._resolve_universe(symbols, exchanges, user_id)
+
             scan_type_list = [t.strip().lower() for t in scan_types.split(",")]
             
             inefficiency_results = {}

--- a/app/services/market_data_feeds.py
+++ b/app/services/market_data_feeds.py
@@ -6,6 +6,8 @@ and other free sources for the AI money manager platform.
 """
 
 import asyncio
+import ast
+import json
 import time
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
@@ -245,14 +247,33 @@ class MarketDataFeeds:
         current_time = time.time()
         
         # ENTERPRISE CIRCUIT BREAKER CHECK
-        breaker = self.circuit_breakers.get(api_name, {})
-        if current_time < breaker.get("open_until", 0):
-            logger.debug(f"Circuit breaker OPEN for {api_name}")
-            return False
-        
+        circuit_breaker = self.circuit_breakers.get(api_name)
+        if circuit_breaker:
+            try:
+                should_try = await circuit_breaker._should_try()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "Circuit breaker check failed",
+                    api=api_name,
+                    error=str(exc),
+                )
+                should_try = True
+
+            if not should_try:
+                logger.debug(f"Circuit breaker OPEN for {api_name}")
+                return False
+
         # Check traditional rate limits
-        limiter = self.rate_limiters.get(api_name, {})
-        
+        limiter = self.rate_limiters.get(api_name)
+        if limiter is None:
+            api_config = self.apis.get(api_name, {})
+            limiter = {
+                "requests": 0,
+                "window_start": current_time,
+                "max_requests": api_config.get("rate_limit", 60),
+            }
+            self.rate_limiters[api_name] = limiter
+
         # Reset window if needed (1 minute windows)
         if current_time - limiter.get("window_start", 0) >= 60:
             limiter["requests"] = 0
@@ -499,44 +520,127 @@ class MarketDataFeeds:
                 "include_market_cap": "true"
             }
             
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, params=params) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        
-                        # Transform data
-                        result = {"success": True, "data": {}}
-                        
-                        for coin_id, coin_data in data.items():
-                            symbol = symbol_map.get(coin_id, coin_id.upper())
-                            result["data"][symbol] = {
-                                "symbol": symbol,
-                                "price": coin_data.get("usd", 0),
-                                "change_24h": coin_data.get("usd_24h_change", 0),
-                                "volume_24h": coin_data.get("usd_24h_vol", 0),
-                                "market_cap": coin_data.get("usd_market_cap", 0),
-                                "timestamp": datetime.utcnow().isoformat(),
-                                "source": "coingecko"
-                            }
-                            
-                            # ENTERPRISE REDIS RESILIENCE - Cache individual prices if Redis is available
-                            if self.redis:
-                                await self.redis.setex(
-                                    f"price:{symbol}",
-                                    self.cache_ttl["price"],
-                                    str({
-                                        "success": True,
-                                        "data": result["data"][symbol]
-                                    })
-                                )
-                        
-                        return result
-                    else:
+            timeout = aiohttp.ClientTimeout(total=6)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                try:
+                    async with session.get(url, params=params) as response:
+                        if response.status == 200:
+                            data = await response.json()
+
+                            # Transform data
+                            result = {"success": True, "data": {}}
+
+                            for coin_id, coin_data in data.items():
+                                symbol = symbol_map.get(coin_id, coin_id.upper())
+                                result["data"][symbol] = {
+                                    "symbol": symbol,
+                                    "price": coin_data.get("usd", 0),
+                                    "change_24h": coin_data.get("usd_24h_change", 0),
+                                    "volume_24h": coin_data.get("usd_24h_vol", 0),
+                                    "market_cap": coin_data.get("usd_market_cap", 0),
+                                    "timestamp": datetime.utcnow().isoformat(),
+                                    "source": "coingecko"
+                                }
+
+                                # ENTERPRISE REDIS RESILIENCE - Cache individual prices if Redis is available
+                                if self.redis:
+                                    await self.redis.setex(
+                                        f"price:{symbol}",
+                                        self.cache_ttl["price"],
+                                        json.dumps({
+                                            "success": True,
+                                            "data": result["data"][symbol]
+                                        })
+                                    )
+
+                            return result
                         return {"success": False, "error": f"API error: {response.status}"}
-                        
+                except asyncio.TimeoutError:
+                    logger.warning("CoinGecko multiple price request timed out", symbols=symbols)
+                    return await self._fallback_cached_prices(symbols)
+
         except Exception as e:
             logger.error("Failed to get multiple prices", error=str(e))
-            return {"success": False, "error": str(e)}
+            return await self._fallback_cached_prices(symbols, error=str(e))
+
+    async def _fallback_cached_prices(
+        self,
+        symbols: List[str],
+        error: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        cached: Dict[str, Any] = {}
+
+        async def load_from_redis(symbol: str) -> Optional[Dict[str, Any]]:
+            if not self.redis:
+                return None
+
+            raw = await self.redis.get(f"price:{symbol}")
+            if not raw:
+                return None
+
+            return self._deserialize_price_cache(raw)
+
+        for symbol in symbols:
+            cached_data = await load_from_redis(symbol)
+            if cached_data:
+                cached[symbol] = cached_data
+
+        if cached:
+            metadata = {"source": "cache"}
+            if error:
+                metadata["error"] = error
+            return {"success": True, "data": cached, "metadata": metadata}
+
+        return {
+            "success": False,
+            "error": error or "Price service unavailable",
+        }
+
+    def _deserialize_price_cache(self, raw: Any) -> Optional[Dict[str, Any]]:
+        """Normalise cached price payloads into dictionaries."""
+
+        payload: Any = raw
+
+        if isinstance(payload, bytes):
+            try:
+                payload = payload.decode()
+            except Exception:  # pragma: no cover - defensive decode
+                payload = payload.decode(errors="ignore") if hasattr(payload, "decode") else payload
+
+        if isinstance(payload, dict):
+            container: Any = payload
+        elif isinstance(payload, str):
+            try:
+                container = json.loads(payload)
+            except (json.JSONDecodeError, TypeError):
+                try:
+                    container = ast.literal_eval(str(payload))
+                except (ValueError, SyntaxError):
+                    return None
+        else:
+            return None
+
+        if not isinstance(container, dict):
+            return None
+
+        data: Any = container.get("data") if "data" in container else container
+
+        if isinstance(data, bytes):
+            try:
+                data = data.decode()
+            except Exception:  # pragma: no cover - defensive decode
+                data = data.decode(errors="ignore") if hasattr(data, "decode") else data
+
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except (json.JSONDecodeError, TypeError):
+                try:
+                    data = ast.literal_eval(str(data))
+                except (ValueError, SyntaxError):
+                    return None
+
+        return data if isinstance(data, dict) else None
 
     async def get_trending_coins(self, limit: int = 10) -> Dict[str, Any]:
         """Get trending coins from CoinGecko."""

--- a/docs/market_analysis_enterprise_plan.md
+++ b/docs/market_analysis_enterprise_plan.md
@@ -1,0 +1,56 @@
+# Market Analysis Service – Enterprise Remediation Plan
+
+## 1. Production symptoms
+
+- `MarketAnalysisService.realtime_price_tracking` still iterates a caller-supplied comma string, waits for **every** configured exchange request to finish per symbol, and only then drops into `get_market_snapshot`; with Render-level latency this blocks `/trading/market-overview` and the chat orchestrators that depend on it.【F:app/services/market_analysis_core.py†L265-L397】
+- The exchange roster that path actually checks is the static `DynamicExchangeManager.exchange_configs`, so even though discovery logic exists elsewhere the hot path always touches the same three venues (Binance, Kraken, KuCoin).【F:app/services/market_analysis_core.py†L105-L145】
+- `_check_rate_limit` in `market_data_feeds` treats `CircuitBreaker` instances like dictionaries, so `breaker.get(...)` raises and the primary price feed falls through to slow fallbacks on every call.【F:app/services/market_data_feeds.py†L243-L266】
+- When the code finally reaches the CoinGecko batch fallback, `get_multiple_prices` performs a bare `aiohttp` request with no timeout or rate-limit short circuit, allowing Render requests to hang until the frontend drops the connection.【F:app/services/market_data_feeds.py†L472-L535】
+- `discover_exchange_assets` calls `_discover_real_spot_assets` sequentially for each requested venue; each helper spins up two 10‑second calls per exchange before processing, so invoking discovery on the request path multiplies latency, and the results are not cached per user.【F:app/services/market_analysis_core.py†L2318-L2433】【F:app/services/market_analysis_core.py†L4051-L4310】
+
+## 2. Architectural gaps versus the intended dynamic system
+
+1. **User-specific exchange scoping is bypassed.** The master controller already looks up connected exchanges per user (`ExchangeAccount`) for coordinated arbitrage, but `realtime_price_tracking` ignores the `user_id` and probes every hard-coded venue.【F:app/services/master_controller.py†L1105-L1158】【F:app/services/market_analysis_core.py†L265-L397】
+2. **Symbol universe never leaves the hot request path.** The discovery functions generate rich inventories, yet they are triggered synchronously by endpoints and do not persist their findings for reuse, forcing cold starts to redo the slow crawl.【F:app/services/market_analysis_core.py†L2318-L2433】
+3. **Exchange adapters are not reusable.** `DynamicExchangeManager.fetch_from_exchange` creates a brand-new `aiohttp.ClientSession` per call, multiplying TLS handshakes and preventing connection pooling when scanning dozens of assets.【F:app/services/market_analysis_core.py†L131-L145】
+4. **Hard-coded pair conversions persist.** Helper methods such as `_convert_to_binance_symbol` maintain a fixed whitelist, defeating the purpose of dynamic discovery and breaking less common assets returned by the scanners.【F:app/services/market_analysis_core.py†L913-L943】
+
+## 3. Remediation blueprint (enterprise-grade, no fixed symbol limits)
+
+### 3.1 Exchange & symbol registry
+
+- Introduce a dedicated `ExchangeUniverseService` that resolves the active exchange list for a user. Populate it from `ExchangeAccount` (or tenancy configuration) and cache it per user in Redis with short TTLs; fall back to platform defaults only when a user has no active links.【F:app/services/master_controller.py†L1105-L1158】
+- Build an `AssetRegistry` backed by Redis/PostgreSQL that stores, per `(user, exchange, asset_type)`, the last successful discovery result. Seed it asynchronously using the existing `_discover_*` routines, but never run them inline with API requests.【F:app/services/market_analysis_core.py†L2318-L2433】【F:app/services/market_analysis_core.py†L4051-L4310】
+- Add an async background job (Render worker or FastAPI startup task) that refreshes each user’s connected exchanges on a rolling schedule (e.g., staggered cron) and republishes the discovered symbol list. When discovery fails, keep serving the last known good snapshot instead of blocking.
+
+### 3.2 Request-path execution model
+
+- Refactor `realtime_price_tracking` to accept structured inputs (`Iterable[SymbolDescriptor]`) instead of comma strings and fetch the user-specific exchange roster from the registry. Use `asyncio.Semaphore` plus `asyncio.wait_for` per exchange task to cap latency (e.g., 3–5 s) while still letting unlimited symbols flow through in batches.【F:app/services/market_analysis_core.py†L265-L397】
+- Stream results back as soon as each symbol’s quorum completes (e.g., use `asyncio.as_completed`) and merge with cached snapshots so large universes are processed progressively rather than sequentially.
+- Replace the per-call `ClientSession` creation in `DynamicExchangeManager` with lifetime-managed sessions keyed by exchange, honouring the API’s base URLs and credentials while enabling connection reuse.【F:app/services/market_analysis_core.py†L105-L145】
+
+### 3.3 Resilient market-data feeds
+
+- Rewrite `_check_rate_limit` to interrogate the existing `CircuitBreaker` instances (`await circuit_breaker._should_try()`) and store breaker open times alongside them, preventing AttributeErrors and re-enabling the fast primary feeds.【F:app/services/market_data_feeds.py†L243-L266】
+- Wrap `get_multiple_prices` and other `aiohttp` calls in explicit `ClientTimeout` plus retry/backoff logic; on timeout, return cached registry data so chat and dashboard consumers still receive a bounded response time.【F:app/services/market_data_feeds.py†L472-L535】
+- Expand symbol mapping to consult the `AssetRegistry` output instead of static dicts, falling back to static pairs only when a symbol has never been discovered.【F:app/services/market_analysis_core.py†L913-L943】
+
+### 3.4 Opportunity & scanner alignment
+
+- Adjust the chat opportunity flows to request symbols from the registry based on scenario (e.g., top 20 by rolling volume on the user’s exchanges) rather than a fixed “SMART_ADAPTIVE” placeholder, ensuring scans scale with each user’s footprint without artificial caps.【F:app/services/master_controller.py†L1105-L1158】
+- Ensure arbitrage and inefficiency scanners operate on the same cached data so subsequent calls reuse the already-fetched orderbook/ticker snapshots, minimising duplicate upstream load.【F:app/services/market_analysis_core.py†L2435-L2648】
+
+### 3.5 Operational safeguards
+
+- Emit structured metrics (success counts, latency buckets) whenever discovery jobs or hot-path aggregations fall back to cached data, so Render monitoring can alert on real degradation instead of silent timeouts.
+- Provide admin tooling to purge or pre-warm the registries, ensuring new deployments can repopulate discovery data before traffic hits the user-facing endpoints.
+
+## 4. Validation strategy
+
+1. Unit-test the refactored `_check_rate_limit` and new registry services to confirm open breakers and rate limits behave correctly under concurrency.【F:app/services/market_data_feeds.py†L243-L266】
+2. Integration-test `realtime_price_tracking` with mocked slow exchanges to verify per-exchange timeouts and streaming responses prevent 180 s stalls even when dozens of symbols are requested.【F:app/services/market_analysis_core.py†L265-L397】
+3. End-to-end smoke tests for `/trading/market-overview` and chat opportunity prompts to ensure they receive responses when CoinGecko and other upstreams are artificially delayed, exercising cache fallbacks instead of hanging.【F:app/services/market_data_feeds.py†L472-L535】
+
+## 5. Expected outcome
+
+Implementing the above restores a truly dynamic, user-scoped market-analysis flow: discovery runs in the background, hot requests pull from cached inventories, and every network call is guarded by explicit deadlines. The UI and chat layers regain sub-second responses without sacrificing breadth—the system can enumerate hundreds of assets per user because the work is scheduled outside the request lifecycle and reused across services.

--- a/docs/opportunity_scan_fix_evaluation.md
+++ b/docs/opportunity_scan_fix_evaluation.md
@@ -1,0 +1,45 @@
+# Opportunity Scan Fix Evaluation
+
+## Summary
+Recent changes introduced the shared price cache and preloading pipeline in
+`MarketAnalysisService` with the goal of accelerating opportunity discovery.
+A manual review of the runtime paths shows that the fix still leaves the chat
+scan vulnerable to multi-minute delays.
+
+## Key findings
+
+1. **Price preloading still performs hundreds of live HTTP calls.**
+   `_preload_price_universe` gathers up to `user_profile.opportunity_scan_limit`
+   assets (50–1000 depending on tier) and invokes
+   `market_analysis_service.preload_exchange_prices` for each entry.
+   Because every preload delegates to `get_exchange_price`, the system will
+   issue one outbound request per asset/exchange pair whenever the cache is
+   cold. With a 5-second timeout and concurrency fixed at 20, warming 1000
+   pairs can still consume more than four minutes on a cold deployment.
+
+2. **Price requests still fan out sequentially per exchange.**
+   `get_exchange_price` looks up Redis/in-memory caches but, on a miss, calls
+   `_fetch_symbol_price_uncached`, which performs a live REST request per
+   exchange without batching. The cache does not help the first request and the
+   preloader simply moves this latency earlier in the request lifecycle.
+
+3. **Strategy scanners immediately read live prices when cache is cold.**
+   The trading strategies now call the shared price cache, but when the cache
+   is empty (Render cold start, new symbol, Redis flush) each strategy still
+   blocks on the same `_fetch_symbol_price_uncached` path. With dozens of
+   symbols per strategy, the chat flow continues to trigger hundreds of
+   5-second waits before the model can respond.
+
+4. **Frontend timeout window remains 180 seconds.**
+   The Axios client used by the chat UI still aborts at three minutes, so the
+   request will surface the "I'm having difficulty" fallback whenever the
+   opportunity scan exceeds that window—precisely what happens during cold
+   starts or slow upstream exchanges.
+
+## Conclusion
+The price cache and preload hooks reduce duplicate calls once data is warm, but
+on the first request they still execute a large number of blocking outbound
+calls. As a result, the Render deployment continues to time out before the chat
+can return opportunities. Additional architectural changes (background
+precomputation, tighter per-request budgets, or streaming partial results) are
+needed before the issue can be considered resolved.

--- a/tests/services/test_chat_service_adapters.py
+++ b/tests/services/test_chat_service_adapters.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.services.chat_service_adapters_fixed import ChatServiceAdaptersFixed
+
+
+@pytest.mark.asyncio
+async def test_discover_opportunities_uses_analysis_payload(monkeypatch):
+    adapter = ChatServiceAdaptersFixed()
+
+    async def fake_market_overview():
+        return {
+            "sentiment": "Bullish",
+            "trend": "Uptrend",
+            "volatility": "Low",
+        }
+
+    async def fake_technical_analysis(_symbols: str):
+        return {
+            "analysis": {
+                "BTC": {"signals": {"buy": 3, "sell": 0}},
+                "ETH": {"signals": {"buy": 0, "sell": 2}},
+            }
+        }
+
+    async def fake_market_sentiment(_symbols: str):
+        return {"sentiment": {}, "overall_sentiment": "Positive"}
+
+    monkeypatch.setattr(adapter, "get_market_overview", fake_market_overview)
+    monkeypatch.setattr(adapter, "get_technical_analysis", fake_technical_analysis)
+    monkeypatch.setattr(adapter, "get_market_sentiment", fake_market_sentiment)
+
+    result = await adapter.discover_opportunities("user-123")
+
+    assert result["opportunities"], "expected non-empty opportunities when buy signals exist"
+    first = result["opportunities"][0]
+    assert first["symbol"] == "BTC"
+    assert first["confidence"] > 0

--- a/tests/services/test_exchange_universe_service.py
+++ b/tests/services/test_exchange_universe_service.py
@@ -1,0 +1,212 @@
+import os
+import types
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///tmp/test.db")
+
+from types import SimpleNamespace
+
+from app.services.exchange_universe_service import (
+    ExchangeUniverseService,
+    _UserAssetPreferences,
+)
+
+
+class DummyAccount:
+    def __init__(self, exchange_name: str, allowed_symbols=None):
+        self.exchange_name = exchange_name
+        self.allowed_symbols = allowed_symbols or []
+
+
+@pytest.fixture
+def exchange_service(monkeypatch):
+    service = ExchangeUniverseService()
+
+    async def noop_store(*args, **kwargs):
+        return None
+
+    async def noop_read(*args, **kwargs):
+        return None
+
+    async def noop_ensure(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_store_in_redis", noop_store)
+    monkeypatch.setattr(service, "_read_from_redis", noop_read)
+    monkeypatch.setattr(service, "_ensure_redis", noop_ensure)
+    monkeypatch.setattr(service, "_get_user_asset_preferences", AsyncMock(return_value=None))
+
+    class StubFilter:
+        VOLUME_TIERS = (
+            SimpleNamespace(name="tier_institutional", priority=1),
+            SimpleNamespace(name="tier_professional", priority=3),
+            SimpleNamespace(name="tier_retail", priority=4),
+            SimpleNamespace(name="tier_any", priority=99),
+        )
+
+        async def get_assets_for_symbol_list(self, symbols):  # pragma: no cover - default noop
+            return {}
+
+    async def get_filter():
+        return StubFilter()
+
+    monkeypatch.setattr(service, "_get_asset_filter", get_filter)
+
+    return service
+
+
+def _bind(method, instance):
+    return types.MethodType(method, instance)
+
+
+@pytest.mark.asyncio
+async def test_get_user_exchanges_prefers_cached_accounts(exchange_service):
+    user_id = str(uuid.uuid4())
+
+    async def first_fetch(self, _user_id):
+        assert _user_id == user_id
+        return [
+            DummyAccount("binance"),
+            DummyAccount("kraken"),
+        ]
+
+    exchange_service._fetch_exchange_accounts = _bind(first_fetch, exchange_service)
+
+    exchanges = await exchange_service.get_user_exchanges(user_id)
+    assert exchanges == ["binance", "kraken"]
+
+    async def fail_fetch(self, _user_id):  # pragma: no cover - guard against extra DB hits
+        raise AssertionError("exchange roster should be served from cache")
+
+    exchange_service._fetch_exchange_accounts = _bind(fail_fetch, exchange_service)
+
+    cached = await exchange_service.get_user_exchanges(user_id)
+    assert cached == exchanges
+
+
+@pytest.mark.asyncio
+async def test_get_symbol_universe_uses_allowed_symbols(exchange_service, monkeypatch):
+    user_id = str(uuid.uuid4())
+
+    async def fetch_accounts(self, _user_id):
+        return [
+            DummyAccount("binance", ["btc", "eth", "sol"]),
+            DummyAccount("kraken", ["ada"]),
+        ]
+
+    exchange_service._fetch_exchange_accounts = _bind(fetch_accounts, exchange_service)
+
+    symbols = await exchange_service.get_symbol_universe(user_id, None, ["binance", "kraken"])
+    assert set(symbols) == {"BTC", "ETH", "SOL", "ADA"}
+
+
+@pytest.mark.asyncio
+async def test_get_symbol_universe_falls_back_when_empty(exchange_service, monkeypatch):
+    user_id = str(uuid.uuid4())
+
+    async def fetch_accounts(self, _user_id):
+        return [DummyAccount("binance")]
+
+    async def fallback(self, limit, min_tier):
+        assert min_tier == "tier_retail"
+        return ["X", "Y", "Z"][: limit or 3]
+
+    exchange_service._fetch_exchange_accounts = _bind(fetch_accounts, exchange_service)
+    exchange_service._fallback_symbols = _bind(fallback, exchange_service)
+
+    symbols = await exchange_service.get_symbol_universe(user_id, None, ["binance"], limit=2)
+    assert symbols == ["X", "Y"]
+
+
+@pytest.mark.asyncio
+async def test_get_symbol_universe_respects_user_asset_preferences(exchange_service, monkeypatch):
+    user_id = str(uuid.uuid4())
+
+    async def fetch_accounts(self, _user_id):
+        return [
+            DummyAccount("binance", ["btc", "sol", "doge", "lowcap"]),
+        ]
+
+    class PrefFilter:
+        VOLUME_TIERS = (
+            SimpleNamespace(name="tier_institutional", priority=1),
+            SimpleNamespace(name="tier_enterprise", priority=2),
+            SimpleNamespace(name="tier_professional", priority=3),
+            SimpleNamespace(name="tier_retail", priority=4),
+            SimpleNamespace(name="tier_micro", priority=6),
+            SimpleNamespace(name="tier_any", priority=99),
+        )
+
+        async def get_assets_for_symbol_list(self, symbols):
+            return {
+                "BTC": SimpleNamespace(tier="tier_institutional", volume_24h_usd=1_500_000_000),
+                "SOL": SimpleNamespace(tier="tier_professional", volume_24h_usd=350_000_000),
+                "DOGE": SimpleNamespace(tier="tier_retail", volume_24h_usd=150_000_000),
+                "LOWCAP": SimpleNamespace(tier="tier_micro", volume_24h_usd=500_000),
+            }
+
+    async def prefs(_user_id):
+        return _UserAssetPreferences(max_tier="tier_professional", symbol_limit=3)
+
+    async def get_filter():
+        return PrefFilter()
+
+    exchange_service._fetch_exchange_accounts = _bind(fetch_accounts, exchange_service)
+    exchange_service._get_user_asset_preferences = AsyncMock(side_effect=prefs)
+    monkeypatch.setattr(exchange_service, "_get_asset_filter", get_filter)
+
+    symbols = await exchange_service.get_symbol_universe(user_id, None, ["binance"])
+
+    assert symbols == ["BTC", "SOL"]
+    assert "LOWCAP" not in symbols
+    assert len(symbols) <= 3
+
+
+@pytest.mark.asyncio
+async def test_read_from_redis_accepts_dict_payload(monkeypatch):
+    service = ExchangeUniverseService()
+
+    class DummyRedis:
+        def __init__(self, mapping):
+            self.mapping = mapping
+
+        async def get(self, key):
+            return self.mapping.get(key)
+
+    redis_data = {
+        "symbols:test": {"symbols": ["btc", "eth"]}
+    }
+
+    service._redis = DummyRedis(redis_data)
+    monkeypatch.setattr(service, "_ensure_redis", AsyncMock())
+
+    result = await service._read_from_redis("symbols:test")
+
+    assert result == ["BTC", "ETH"]
+
+
+@pytest.mark.asyncio
+async def test_read_from_redis_accepts_list_payload(monkeypatch):
+    service = ExchangeUniverseService()
+
+    class DummyRedis:
+        def __init__(self, mapping):
+            self.mapping = mapping
+
+        async def get(self, key):
+            return self.mapping.get(key)
+
+    redis_data = {
+        "symbols:test_list": [b"sol", "avax"]
+    }
+
+    service._redis = DummyRedis(redis_data)
+    monkeypatch.setattr(service, "_ensure_redis", AsyncMock())
+
+    result = await service._read_from_redis("symbols:test_list")
+
+    assert result == ["SOL", "AVAX"]

--- a/tests/services/test_market_analysis_arbitrage.py
+++ b/tests/services/test_market_analysis_arbitrage.py
@@ -1,0 +1,122 @@
+import asyncio
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///tmp/test.db")
+
+from app.services.exchange_universe_service import exchange_universe_service
+from app.services.market_analysis_core import MarketAnalysisService
+
+
+@pytest.mark.asyncio
+async def test_arbitrage_scanner_uses_dynamic_universe(monkeypatch):
+    service = MarketAnalysisService()
+
+    exchanges_mock = AsyncMock(return_value=["binance", "kraken"])
+    symbols_mock = AsyncMock(return_value=["BTC", "ETH"])
+
+    monkeypatch.setattr(exchange_universe_service, "get_user_exchanges", exchanges_mock)
+    monkeypatch.setattr(exchange_universe_service, "get_symbol_universe", symbols_mock)
+
+    async def fake_collect(symbol: str, exchange_list):
+        return [
+            {
+                "exchange": "binance",
+                "price": 100.0,
+                "volume": 10.0,
+                "timestamp": "2024-01-01T00:00:00Z",
+            },
+            {
+                "exchange": "kraken",
+                "price": 101.0,
+                "volume": 8.0,
+                "timestamp": "2024-01-01T00:00:01Z",
+            },
+        ]
+
+    monkeypatch.setattr(service, "_collect_symbol_prices_for_arbitrage", fake_collect)
+
+    result = await service.cross_exchange_arbitrage_scanner(
+        symbols="SMART_ADAPTIVE",
+        exchanges="all",
+        min_profit_bps=10,
+        user_id="user-1",
+    )
+
+    await service.exchange_manager.close()
+
+    assert result["success"] is True
+    summary = result["data"]["summary"]
+    assert summary["symbols_scanned"] == 2
+    assert summary["exchanges_scanned"] == 2
+    assert summary["total_opportunities"] > 0
+    assert exchanges_mock.await_count == 1
+    assert symbols_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_symbol_prices_timeout(monkeypatch):
+    service = MarketAnalysisService()
+
+    async def fake_get_symbol_price(exchange, symbol):
+        await asyncio.sleep(0)
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(service, "_get_symbol_price", fake_get_symbol_price)
+
+    results = await service._collect_symbol_prices_for_arbitrage("BTC", ["binance", "kraken"])
+
+    await service.exchange_manager.close()
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_arbitrage_scanner_completes_when_exchanges_timeout(monkeypatch):
+    service = MarketAnalysisService()
+    service._per_exchange_timeout = 0.05
+
+    monkeypatch.setattr(
+        exchange_universe_service,
+        "get_user_exchanges",
+        AsyncMock(return_value=["fast", "slow", "faster"]),
+    )
+    monkeypatch.setattr(
+        exchange_universe_service,
+        "get_symbol_universe",
+        AsyncMock(return_value=["BTC"]),
+    )
+
+    async def fake_get_symbol_price(exchange, symbol):
+        if exchange == "slow":
+            await asyncio.sleep(0.2)
+            return {"price": 105.0, "volume": 1.0}
+        if exchange == "fast":
+            await asyncio.sleep(0.01)
+            return {"price": 100.0, "volume": 5.0}
+        await asyncio.sleep(0.01)
+        return {"price": 102.0, "volume": 4.0}
+
+    monkeypatch.setattr(service, "_get_symbol_price", fake_get_symbol_price)
+
+    result = await asyncio.wait_for(
+        service.cross_exchange_arbitrage_scanner(
+            symbols="SMART_ADAPTIVE",
+            exchanges="all",
+            min_profit_bps=10,
+            user_id="user-123",
+        ),
+        timeout=1,
+    )
+
+    await service.exchange_manager.close()
+
+    assert result["success"] is True
+    opportunities = result["data"]["opportunities"]
+    # Only the fast exchanges should contribute because the slow exchange timed out
+    assert all(opp["buy_exchange"] != "slow" and opp["sell_exchange"] != "slow" for opp in opportunities)
+    # Ensure at least one opportunity was generated from fast vs faster
+    assert any({opp["buy_exchange"], opp["sell_exchange"]} == {"fast", "faster"} for opp in opportunities)

--- a/tests/services/test_market_analysis_price_cache.py
+++ b/tests/services/test_market_analysis_price_cache.py
@@ -1,0 +1,102 @@
+import os
+import types
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///tmp/test.db")
+
+from app.services.market_analysis_core import MarketAnalysisService
+from app.services.trading_strategies import TradingStrategiesService
+
+
+@pytest.mark.asyncio
+async def test_get_exchange_price_uses_in_memory_cache(monkeypatch):
+    service = MarketAnalysisService()
+
+    async def fake_load(self, cache_key):
+        return None
+
+    async def fake_store(self, cache_key, data, ttl):
+        return None
+
+    fetch_calls = {"count": 0}
+
+    async def fake_bulk(self, exchange, symbols):
+        fetch_calls["count"] += 1
+        return {
+            self._normalize_symbol_for_exchange(exchange, s)[1]: {
+                "price": 101.0,
+                "volume": 1.0,
+                "timestamp": "now",
+            }
+            for s in symbols
+        }
+
+    monkeypatch.setattr(service, "_load_price_from_redis", types.MethodType(fake_load, service))
+    monkeypatch.setattr(service, "_store_price_in_redis", types.MethodType(fake_store, service))
+    monkeypatch.setattr(service, "_fetch_bulk_symbol_prices", types.MethodType(fake_bulk, service))
+
+    first = await service.get_exchange_price("binance", "btc")
+    second = await service.get_exchange_price("binance", "BTC/USDT")
+
+    assert first["price"] == pytest.approx(101.0)
+    assert second["price"] == pytest.approx(101.0)
+    assert fetch_calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_preload_exchange_prices_deduplicates(monkeypatch):
+    service = MarketAnalysisService()
+
+    calls = []
+
+    async def fake_bulk(self, exchange, symbols):
+        calls.append((exchange, tuple(sorted(symbols))))
+        return {
+            symbol: {"price": 1.0, "timestamp": "now"}
+            for symbol in symbols
+        }
+
+    async def fake_store(self, cache_key, data, ttl):
+        return None
+
+    monkeypatch.setattr(service, "_fetch_bulk_symbol_prices", types.MethodType(fake_bulk, service))
+    monkeypatch.setattr(service, "_store_price_in_redis", types.MethodType(fake_store, service))
+
+    await service.preload_exchange_prices(
+        [("binance", "btc"), ("binance", "BTC/USDT"), ("kraken", "ETH/USD")],
+        concurrency=2,
+    )
+
+    assert any(
+        exchange == "binance" and ("BTC/USDT",) == tuple(symbols)
+        for exchange, symbols in calls
+    )
+    assert any(exchange == "kraken" for exchange, _ in calls)
+
+
+@pytest.mark.asyncio
+async def test_trading_strategies_price_uses_shared_service(monkeypatch):
+    service = TradingStrategiesService()
+
+    class StubAnalysis:
+        def __init__(self):
+            self.calls = []
+
+        async def get_exchange_price(self, exchange, symbol, ttl=None):
+            self.calls.append((exchange, symbol))
+            return {"price": 255.0, "timestamp": "now"}
+
+    stub = StubAnalysis()
+
+    monkeypatch.setattr(
+        "app.services.trading_strategies.market_analysis_service",
+        stub,
+    )
+
+    result = await service._get_symbol_price("auto", "btc")
+
+    assert result["success"] is True
+    assert result["price"] == pytest.approx(255.0)
+    assert stub.calls == [("binance", "BTC/USDT")]

--- a/tests/services/test_market_data_rate_limit.py
+++ b/tests/services/test_market_data_rate_limit.py
@@ -1,0 +1,92 @@
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///tmp/test.db")
+
+from app.services.market_data_feeds import MarketDataFeeds
+
+
+class FakeCircuitBreaker:
+    def __init__(self, allow: bool = True):
+        self.allow = allow
+        self.failure_count = 0
+        self.success_count = 0
+
+    async def _should_try(self) -> bool:
+        return self.allow
+
+    async def _record_failure(self) -> None:
+        self.failure_count += 1
+
+    async def _record_success(self) -> None:
+        self.success_count += 1
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limit_respects_circuit_breaker(monkeypatch):
+    feeds = MarketDataFeeds()
+    feeds.circuit_breakers["coingecko"] = FakeCircuitBreaker(allow=False)
+
+    allowed = await feeds._check_rate_limit("coingecko")
+    assert not allowed
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limit_counts_requests(monkeypatch):
+    feeds = MarketDataFeeds()
+    feeds.circuit_breakers["coingecko"] = FakeCircuitBreaker(allow=True)
+
+    limiter = feeds.rate_limiters["coingecko"]
+    limiter["requests"] = limiter["max_requests"] - 1
+
+    assert await feeds._check_rate_limit("coingecko") is True
+    assert limiter["requests"] == limiter["max_requests"]
+
+    assert await feeds._check_rate_limit("coingecko") is False
+
+
+@pytest.mark.asyncio
+async def test_fallback_cached_prices_accepts_dict_payload(monkeypatch):
+    feeds = MarketDataFeeds()
+
+    class DummyRedis:
+        def __init__(self, mapping):
+            self.mapping = mapping
+
+        async def get(self, key):
+            return self.mapping.get(key)
+
+    feeds.redis = DummyRedis({
+        "price:BTC": {"data": {"price": 25000, "symbol": "BTC"}}
+    })
+
+    response = await feeds._fallback_cached_prices(["BTC"])
+
+    assert response["success"] is True
+    assert response["data"]["BTC"]["price"] == 25000
+
+
+@pytest.mark.asyncio
+async def test_fallback_cached_prices_accepts_bytes_json(monkeypatch):
+    feeds = MarketDataFeeds()
+
+    class DummyRedis:
+        def __init__(self, mapping):
+            self.mapping = mapping
+
+        async def get(self, key):
+            return self.mapping.get(key)
+
+    payload = json.dumps({"data": {"price": 123, "symbol": "ETH"}}).encode()
+
+    feeds.redis = DummyRedis({
+        "price:ETH": payload
+    })
+
+    response = await feeds._fallback_cached_prices(["ETH"])
+
+    assert response["success"] is True
+    assert response["data"]["ETH"]["price"] == 123

--- a/tests/services/test_trading_strategies_universe.py
+++ b/tests/services/test_trading_strategies_universe.py
@@ -1,0 +1,141 @@
+import os
+from pathlib import Path
+
+import pytest
+from unittest.mock import AsyncMock
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+
+# Ensure application modules are importable when tests run in isolation
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from app.services.trading_strategies import trading_strategies_service
+from app.services import trading_strategies as trading_module
+
+
+@pytest.mark.asyncio
+async def test_execute_strategy_passes_parameters_to_funding(monkeypatch):
+    funding_mock = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(trading_strategies_service, "funding_arbitrage", funding_mock)
+
+    params = {"symbols": "SOL,ADA", "exchanges": "binance,bybit", "min_funding_rate": 0.01}
+
+    await trading_strategies_service.execute_strategy(
+        function="funding_arbitrage",
+        parameters=params,
+        user_id="user-123",
+    )
+
+    funding_mock.assert_awaited_once()
+    kwargs = funding_mock.await_args.kwargs
+    assert kwargs["symbols"] == "SOL,ADA"
+    assert kwargs["exchanges"] == "binance,bybit"
+    assert kwargs["min_funding_rate"] == 0.01
+    assert kwargs["user_id"] == "user-123"
+
+
+@pytest.mark.asyncio
+async def test_execute_strategy_passes_universe_to_statistical(monkeypatch):
+    stat_mock = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(trading_strategies_service, "statistical_arbitrage", stat_mock)
+
+    params = {"universe": "BTC,ETH", "exchanges": "binance,kraken"}
+
+    await trading_strategies_service.execute_strategy(
+        function="statistical_arbitrage",
+        strategy_type="mean_reversion",
+        parameters=params,
+        user_id="user-456",
+    )
+
+    stat_mock.assert_awaited_once()
+    kwargs = stat_mock.await_args.kwargs
+    assert kwargs["universe"] == "BTC,ETH"
+    assert kwargs["parameters"] == params
+    assert kwargs["user_id"] == "user-456"
+
+
+@pytest.mark.asyncio
+async def test_funding_arbitrage_dynamic_universe(monkeypatch):
+    exchange_mock = AsyncMock(return_value=["binance", "bybit"])
+    symbol_mock = AsyncMock(return_value=["BTCUSDT", "SOL"])
+    monkeypatch.setattr(trading_module.exchange_universe_service, "get_user_exchanges", exchange_mock)
+    monkeypatch.setattr(trading_module.exchange_universe_service, "get_symbol_universe", symbol_mock)
+
+    async def fake_funding(symbol_pair: str, exchange: str):
+        base = 0.015 if exchange == "binance" else -0.005
+        return {
+            "current_funding_rate": base,
+            "predicted_funding_rate": base,
+            "funding_interval": 8,
+        }
+
+    funding_info_mock = AsyncMock(side_effect=fake_funding)
+    monkeypatch.setattr(trading_strategies_service, "_get_perpetual_funding_info", funding_info_mock)
+
+    result = await trading_strategies_service.funding_arbitrage(
+        symbols="SMART_ADAPTIVE",
+        exchanges="all",
+        min_funding_rate=0.001,
+        user_id="user-789",
+    )
+
+    exchange_mock.assert_awaited_once_with(
+        "user-789",
+        [],
+        default_exchanges=trading_strategies_service.market_analyzer.exchange_manager.exchange_configs.keys(),
+    )
+    symbol_mock.assert_awaited_once_with("user-789", None, ["binance", "bybit"])
+
+    analysis = result["funding_arbitrage_analysis"]
+    assert set(analysis["funding_analysis"].keys()) == {"BTC", "SOL"}
+    assert analysis["opportunities"], "expected arbitrage opportunities to be generated"
+
+
+@pytest.mark.asyncio
+async def test_statistical_arbitrage_dynamic_universe(monkeypatch):
+    exchange_mock = AsyncMock(return_value=["kraken", "binance"])
+    symbol_mock = AsyncMock(return_value=["ETHUSDT", "AVAX"])
+    monkeypatch.setattr(trading_module.exchange_universe_service, "get_user_exchanges", exchange_mock)
+    monkeypatch.setattr(trading_module.exchange_universe_service, "get_symbol_universe", symbol_mock)
+
+    price_data = {
+        "ETHUSDT": {"price": 1800.0, "volume": 5_000_000.0, "change_24h": 2.5},
+        "AVAXUSDT": {"price": 35.0, "volume": 1_500_000.0, "change_24h": -1.0},
+    }
+
+    async def fake_price(exchange: str, symbol: str):
+        record = price_data.get(symbol)
+        if not record:
+            return None
+        return {
+            "price": record["price"],
+            "volume": record["volume"],
+            "change_24h": record["change_24h"],
+        }
+
+    price_mock = AsyncMock(side_effect=fake_price)
+    monkeypatch.setattr(trading_strategies_service, "_get_symbol_price", price_mock)
+
+    result = await trading_strategies_service.statistical_arbitrage(
+        universe="SMART_ADAPTIVE",
+        parameters={"exchanges": "kraken", "max_universe": 10},
+        user_id="user-999",
+    )
+
+    exchange_mock.assert_awaited_once_with(
+        "user-999",
+        ["kraken"],
+        default_exchanges=trading_strategies_service.market_analyzer.exchange_manager.exchange_configs.keys(),
+    )
+    symbol_mock.assert_awaited_once_with("user-999", None, ["kraken", "binance"], limit=10)
+
+    analysis = result["statistical_arbitrage_analysis"]
+    assert analysis["universe"] == ["ETH", "AVAX"], analysis
+    assert analysis["universe_analysis"]["exchanges_scanned"] == ["kraken", "binance"]
+    assert analysis["opportunities"], "expected stat-arb opportunities to be generated"


### PR DESCRIPTION
## Summary
- add in-memory scan result caching with background orchestration and partial progress snapshots to user opportunity discovery
- expose a discovery wrapper that reuses cached results, returns partial responses on timeout, and falls back gracefully when scans are still in flight
- extend opportunity discovery tests to cover the new partial-result flow

## Testing
- pytest tests/services/test_user_opportunity_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68df73d837b883229bc11d0963a333bd