### PR TITLE
Decouple opportunity discovery latency from chat responses

### DIFF
--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -3257,8 +3257,8 @@ class UserOpportunityDiscoveryService(LoggerMixin):
                         )
                         return None
 
-                # Cache is fresh for 10 minutes for non-zero results, 2 minutes for zero results
-                max_age = timedelta(minutes=10) if total_opportunities > 0 else timedelta(seconds=metadata.get("zero_ttl_seconds", 120))
+                # Cache is fresh for 5 minutes for non-zero results, 2 minutes for zero results
+                max_age = timedelta(minutes=5) if total_opportunities > 0 else timedelta(seconds=metadata.get("zero_ttl_seconds", 120))
                 if datetime.utcnow() - cache_time < max_age:
                     return payload
 
@@ -3303,7 +3303,7 @@ class UserOpportunityDiscoveryService(LoggerMixin):
                 }
             }
 
-            ttl_seconds = 900 if total_opportunities > 0 else 120
+            ttl_seconds = 300 if total_opportunities > 0 else 120
             await self.redis.set(cache_key, json.dumps(cache_entry), ex=ttl_seconds)
 
             # Update last scan time

--- a/app/services/user_opportunity_discovery.py
+++ b/app/services/user_opportunity_discovery.py
@@ -110,7 +110,7 @@ class UserOpportunityDiscoveryService(LoggerMixin):
         self.opportunity_cache = {}
         self._scan_tasks: Dict[str, asyncio.Task] = {}
         self._scan_cache_lock = asyncio.Lock()
-        self._scan_cache_ttl = 1800  # 30 minutes - increased from 10 to reduce expensive scans
+        self._scan_cache_ttl = 300  # 5 minutes to align with fast-refresh chat expectations
         self._partial_cache_ttl = 300  # 5 minutes - increased from 2 for better partial result reuse
         self._scan_response_budget = 150.0  # 150 seconds - allow all 14 strategies to complete (portfolio optimization takes ~80s)
 
@@ -444,59 +444,95 @@ class UserOpportunityDiscoveryService(LoggerMixin):
             return copy.deepcopy(cached_entry.payload)
 
         task = self._scan_tasks.get(user_id)
-        if not task or task.done():
+        if task and task.done():
+            self._scan_tasks.pop(user_id, None)
+            task = None
+
+        scan_id: Optional[str] = getattr(task, "scan_id", None)
+
+        if not task:
+            scan_id = f"user_discovery_{user_id}_{int(time.time())}"
             task = asyncio.create_task(
                 self._execute_opportunity_discovery(
                     user_id=user_id,
                     force_refresh=force_refresh,
                     include_strategy_recommendations=include_strategy_recommendations,
-                )
+                    existing_scan_id=scan_id,
+                ),
+                name=f"opportunity-discovery:{scan_id}",
             )
+            setattr(task, "scan_id", scan_id)
             self._scan_tasks[user_id] = task
             self._schedule_scan_cleanup(user_id, task)
 
         if cached_entry and not force_refresh:
-            return copy.deepcopy(cached_entry.payload)
-
-        try:
-            result = await asyncio.wait_for(
-                asyncio.shield(task),
-                timeout=self._scan_response_budget,
+            payload = copy.deepcopy(cached_entry.payload)
+            metadata = payload.setdefault("metadata", {})
+            metadata.setdefault(
+                "message",
+                "Returning cached opportunity results while a fresh scan completes in the background.",
             )
-            return copy.deepcopy(result)
-        except asyncio.TimeoutError:
-            fallback_entry = await self._get_cached_scan_entry(user_id)
-            if fallback_entry:
-                payload = copy.deepcopy(fallback_entry.payload)
-                metadata = payload.setdefault("metadata", {})
-                metadata.setdefault(
-                    "message",
-                    "Returning cached opportunity results while a fresh scan completes in the background.",
-                )
-                metadata.setdefault(
-                    "scan_state",
-                    "partial" if fallback_entry.partial else "cached",
-                )
-                metadata["generated_at"] = metadata.get("generated_at", datetime.utcnow().isoformat())
-                return payload
+            metadata.setdefault(
+                "scan_state",
+                "partial" if cached_entry.partial else "cached",
+            )
+            metadata.setdefault("generated_at", datetime.utcnow().isoformat())
+            return payload
 
-            fallback_scan_id = f"fallback_{user_id}_{int(time.time())}"
-            fallback_result = await self._provide_fallback_opportunities(user_id, fallback_scan_id)
-            return {
-                "success": False,
-                "scan_id": fallback_scan_id,
-                "user_id": user_id,
-                "opportunities": fallback_result.get("opportunities", []),
-                "total_opportunities": len(fallback_result.get("opportunities", [])),
-                "message": "A fresh opportunity scan is still running. Returning fallback guidance while processing completes.",
-                "fallback_used": True,
-            }
+        # For force refresh requests allow a brief wait for fresh data
+        if force_refresh:
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.shield(task),
+                    timeout=5.0,
+                )
+                return copy.deepcopy(result)
+            except asyncio.TimeoutError:
+                pass
+
+        if not scan_id:
+            scan_id = getattr(task, "scan_id", f"user_discovery_{user_id}_{int(time.time())}")
+
+        placeholder_payload = {
+            "success": True,
+            "scan_id": scan_id,
+            "user_id": user_id,
+            "opportunities": [],
+            "total_opportunities": 0,
+            "message": "Opportunity scan started. We'll notify you as soon as results are ready.",
+            "scan_state": "pending",
+            "metadata": {
+                "scan_state": "pending",
+                "message": "Scanning your active strategies for new opportunities...",
+                "strategies_completed": 0,
+                "total_strategies": 0,
+                "generated_at": datetime.utcnow().isoformat(),
+            },
+            "background_scan": True,
+        }
+
+        await self._update_cached_scan_result(
+            user_id,
+            placeholder_payload,
+            partial=True,
+        )
+
+        self.logger.info(
+            "Returning pending opportunity scan placeholder",
+            user_id=user_id,
+            scan_id=scan_id,
+            force_refresh=force_refresh,
+        )
+
+        return copy.deepcopy(placeholder_payload)
 
     async def _execute_opportunity_discovery(
         self,
         user_id: str,
         force_refresh: bool = False,
-        include_strategy_recommendations: bool = True
+        include_strategy_recommendations: bool = True,
+        *,
+        existing_scan_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         MAIN ENTRY POINT: Discover all opportunities for user based on their strategy portfolio.
@@ -505,7 +541,7 @@ class UserOpportunityDiscoveryService(LoggerMixin):
         """
         
         discovery_start_time = time.time()
-        scan_id = f"user_discovery_{user_id}_{int(time.time())}"
+        scan_id = existing_scan_id or f"user_discovery_{user_id}_{int(time.time())}"
         
         # ENTERPRISE PERFORMANCE METRICS
         metrics = {

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -506,7 +506,7 @@ export const useChatStore = create<ChatState>()(
         try {
           const { apiClient } = await import('@/lib/api/client');
 
-          const response = await apiClient.post('/chat/decision/approve', {
+          const response = await apiClient.post('/chat/action/confirm', {
             decision_id: decisionId,
             approved: approved,
             modifications: {}

--- a/investigations/opportunity_timeout_analysis.md
+++ b/investigations/opportunity_timeout_analysis.md
@@ -1,0 +1,44 @@
+# Opportunity Discovery Chat Timeout Investigation
+
+## Summary
+- **Environment:** Production deployment at `cryptouniverse.onrender.com` and frontend `cryptouniverse-frontend.onrender.com` (Render).
+- **User Account:** `admin@cryptouniverse.com` / `AdminPass123!`.
+- **Focus:** Chat messages that ask the AI money manager to "find opportunities" hang until the client times out. Streaming responses on the frontend fail for the same request type.
+- **Latest trace correlation:** A follow-up Render-hosted trace (205 s successful responses, 490 s client timeout on another phrasing, HTTP 405s on `/chat/quick/opportunities`) reproduces the same slow synchronous opportunity discovery path rather than exposing a new defect. The "streaming" success recorded after ~180 s still reflects the delayed generator handoff described below, so the new trace aligns with the original diagnosis.
+
+## Reproduction Steps
+1. Authenticate via REST API:
+   - `POST /api/v1/auth/login` succeeds and returns an access token (HTTP 200).【29622d†L1-L5】
+2. Start a chat session:
+   - `POST /api/v1/chat/message` with `"Hello"` returns immediately (HTTP 200) with a greeting and session ID (`eb712753-c295-48a3-9ea6-bfcc00e02468`).【fae607†L1-L4】
+3. Ask for opportunities in the same session:
+   - `POST /api/v1/chat/message` with `"Find some trading opportunities for me"` does not return before the 120 s client timeout and raises `ReadTimeoutError` on the client side.【78468a†L1-L45】
+
+## Backend Findings
+- `UnifiedChatService.process_message` performs four steps before it can send a response. Even in streaming mode it waits for `_gather_context_data(...)` to finish before returning the async generator that feeds SSE/WebSocket responses.【F:app/services/unified_chat_service.py†L1344-L1462】
+- When the detected intent is `OPPORTUNITY_DISCOVERY`, `_gather_context_data` calls `user_opportunity_discovery.discover_opportunities_for_user(...)` directly and awaits the full discovery pipeline. The method only uses cached data if a prior scan succeeded; otherwise it performs a fresh scan before streaming can start.【F:app/services/unified_chat_service.py†L2209-L2315】
+- `UserOpportunityDiscoveryService` is tuned for long-running scans. Its `_scan_response_budget` allows up to 150 s for a scan, it spins up concurrent tasks for every strategy, and it touches multiple subsystems (portfolio cache, asset discovery, optimization).【F:app/services/user_opportunity_discovery.py†L86-L153】【F:app/services/user_opportunity_discovery.py†L431-L500】
+- The service starts new scans with `asyncio.create_task(...)` and then waits up to `_scan_response_budget` seconds for them to finish. Without cached results this means the chat request blocks until the scan completes. If the scan overruns, the chat call will also run past common HTTP timeouts (Render's ingress and the browser both default below 150 s).【F:app/services/user_opportunity_discovery.py†L431-L493】
+
+## Frontend Findings
+- The React chat UI opens an SSE connection to `/api/v1/unified-chat/stream` and expects to receive `processing` / `progress` events quickly. It passes the JWT token in the query string per `get_current_user_sse` requirements.【F:frontend/src/components/chat/ChatInterface.tsx†L295-L358】【F:app/api/dependencies/sse_auth.py†L20-L71】
+- If the SSE stream fails it falls back to the REST endpoint `/unified-chat/message`, but the fallback uses the same synchronous backend path and therefore inherits the long-running call and timeout.【F:frontend/src/components/chat/ChatInterface.tsx†L404-L451】
+- Because the backend does not return the SSE generator until after `_gather_context_data` completes, the browser never receives the initial event; the EventSource eventually emits `error`, triggering the fallback (which still times out).
+
+### Relation to the new trace output
+- The automated script's "✅ HTTP streaming working (183.60s, 10 chunks)" entry is consistent with `_gather_context_data` finishing only after opportunity discovery and then yielding cached progress chunks; the 183 s delay maps to the same blocking call chain documented above.【F:app/services/unified_chat_service.py†L1344-L1462】【F:app/services/unified_chat_service.py†L2209-L2315】
+- Mixed results (20 s vs. 205 s vs. 490 s + timeout) mirror the `_scan_response_budget` and cache behavior in `UserOpportunityDiscoveryService`: cached runs return within ~20 s, uncached runs wait the full scan, and overruns exceed client limits.【F:app/services/user_opportunity_discovery.py†L86-L153】【F:app/services/user_opportunity_discovery.py†L431-L500】
+- The repeated HTTP 405 on `/chat/quick/opportunities` reflects that the deployed API only exposes the quick helper at the versioned path `/api/v1/unified-chat/quick/opportunities`; calling the unprefixed `/chat/...` route therefore misses the FastAPI registration (POST handler lives on the versioned router).【F:app/api/v1/endpoints/unified_chat.py†L803-L832】【F:app/api/v1/router.py†L36-L52】
+
+## Root Cause Hypothesis
+1. **Synchronous opportunity discovery pipeline:** Opportunity scanning is engineered as a lengthy batch job (up to 150 s). The unified chat endpoint awaits the entire scan—even in streaming mode—before yielding the first byte to the client. Requests that lack cached results therefore exceed client/server timeouts.
+2. **Streaming lifecycle mismatch:** Progress events are emitted only after the slow discovery call returns, so SSE/WebSocket streams cannot open in time. Frontend streaming then fails, and the REST fallback also stalls, producing the observed timeout.
+
+## Suggested Next Steps
+- Decouple opportunity discovery from the chat request. Options:
+  - Kick off the discovery task in the background (similar to `/api/v1/opportunities/discover`) and immediately return cached/placeholder content with polling instructions.
+  - Or allow streaming to begin before discovery finishes by yielding a generator that polls the in-progress task and emits progress updates while the scan runs.
+- Lower `_scan_response_budget` or make it configurable so HTTP requests do not wait longer than platform limits.
+- Ensure the frontend surfaces a clear message when the backend reports `status: scanning` so users are guided to retry/poll instead of hanging indefinitely.
+
+These changes would keep the enterprise opportunity pipeline intact while preventing chat clients and SSE streams from hitting hard timeouts.

--- a/tests/test_opportunity_discovery_pending.py
+++ b/tests/test_opportunity_discovery_pending.py
@@ -1,0 +1,98 @@
+import asyncio
+import contextlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from app.services.user_opportunity_discovery import (
+    UserOpportunityDiscoveryService,
+    _CachedOpportunityResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_discover_returns_pending_placeholder(monkeypatch):
+    service = UserOpportunityDiscoveryService()
+
+    async def fake_get_cached_scan_entry(user_id: str) -> Any:
+        return None
+
+    async def fake_update_cached_scan_result(user_id: str, payload: dict, *, partial: bool) -> None:
+        # Pretend we stored the payload successfully without touching Redis
+        return None
+
+    async def fake_execute(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return {"success": True, "opportunities": [{"id": "demo"}]}
+
+    monkeypatch.setattr(service, "_get_cached_scan_entry", fake_get_cached_scan_entry)
+    monkeypatch.setattr(service, "_update_cached_scan_result", fake_update_cached_scan_result)
+    monkeypatch.setattr(service, "_execute_opportunity_discovery", fake_execute)
+    monkeypatch.setattr(service, "_schedule_scan_cleanup", lambda *args, **kwargs: None)
+
+    result = await service.discover_opportunities_for_user("user-test")
+
+    assert result["success"] is True
+    assert result["metadata"]["scan_state"] == "pending"
+    assert result["background_scan"] is True
+
+    # Ensure we clean up the background task to avoid warnings
+    await asyncio.sleep(0)
+    for task in list(service._scan_tasks.values()):
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_discover_returns_partial_cache(monkeypatch):
+    service = UserOpportunityDiscoveryService()
+
+    loop_time = asyncio.get_running_loop().time()
+    cached_payload = {
+        "success": True,
+        "opportunities": [],
+        "metadata": {
+            "scan_state": "partial",
+            "strategies_completed": 2,
+            "total_strategies": 4,
+        },
+    }
+
+    async def fake_get_cached_scan_entry(user_id: str) -> _CachedOpportunityResult:
+        return _CachedOpportunityResult(
+            payload=cached_payload,
+            expires_at=loop_time + 60,
+            partial=True,
+        )
+
+    async def fake_update_cached_scan_result(user_id: str, payload: dict, *, partial: bool) -> None:
+        return None
+
+    async def fake_execute(*args, **kwargs):
+        return {"success": True, "opportunities": []}
+
+    monkeypatch.setattr(service, "_get_cached_scan_entry", fake_get_cached_scan_entry)
+    monkeypatch.setattr(service, "_update_cached_scan_result", fake_update_cached_scan_result)
+    monkeypatch.setattr(service, "_execute_opportunity_discovery", fake_execute)
+    monkeypatch.setattr(service, "_schedule_scan_cleanup", lambda *args, **kwargs: None)
+
+    result = await service.discover_opportunities_for_user("user-test")
+
+    assert result["metadata"]["scan_state"] == "partial"
+    assert "message" in result["metadata"]
+
+    for task in list(service._scan_tasks.values()):
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/test_unified_chat_opportunity_streaming.py
+++ b/tests/test_unified_chat_opportunity_streaming.py
@@ -1,0 +1,94 @@
+import asyncio
+from datetime import datetime
+from typing import Dict
+
+import pytest
+
+from app.services.unified_chat_service import (
+    UnifiedChatService,
+    ChatIntent,
+    ChatSession,
+    InterfaceType,
+    ConversationMode,
+    TradingMode,
+)
+
+
+@pytest.mark.asyncio
+async def test_gather_opportunity_context_uses_placeholder_and_caches(monkeypatch):
+    service = UnifiedChatService()
+    service._redis_initialized = True
+    service.redis = None
+
+    placeholder = service._get_placeholder_opportunities("user-test", scan_id="scan-123")
+
+    async def fake_discover(user_id: str, **kwargs):
+        await asyncio.sleep(0)
+        return placeholder
+
+    async def slow_optimization(user_id: str, user_config: Dict[str, str]):
+        try:
+            await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            raise
+
+    scheduled = False
+
+    def record_schedule(user_id: str, user_config: Dict[str, str]) -> None:
+        nonlocal scheduled
+        scheduled = True
+
+    session = ChatSession(
+        session_id="session-1",
+        user_id="user-test",
+        interface=InterfaceType.WEB_CHAT,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        trading_mode=TradingMode.BALANCED,
+        created_at=datetime.utcnow(),
+        last_activity=datetime.utcnow(),
+        context={},
+        messages=[],
+    )
+
+    monkeypatch.setattr(service, "opportunity_discovery", type("_S", (), {
+        "discover_opportunities_for_user": staticmethod(fake_discover)
+    })())
+    monkeypatch.setattr(service, "_run_portfolio_optimization", slow_optimization)
+    monkeypatch.setattr(service, "_schedule_portfolio_optimization_refresh", record_schedule)
+
+    start = asyncio.get_running_loop().time()
+    context = await service._gather_context_data(
+        {"intent": ChatIntent.OPPORTUNITY_DISCOVERY},
+        "user-test",
+        session,
+        user_config={"risk_tolerance": "balanced"},
+    )
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 1.2, "gather_context should return immediately with placeholder"
+    assert context["opportunities"]["scan_state"] == "pending"
+    assert scheduled is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_generator_emits_progress_before_completion():
+    service = UnifiedChatService()
+    service._redis_initialized = True
+    service.redis = None
+
+    placeholder = service._get_placeholder_opportunities("user-test", scan_id="scan-progress")
+    await service._cache_opportunities("user-test", placeholder, partial=True)
+
+    async def complete_context():
+        await asyncio.sleep(0.2)
+        return {"opportunities": [{"id": "ready"}], "metadata": {"scan_state": "complete"}}
+
+    context_task = asyncio.create_task(complete_context())
+
+    events = []
+    async for update in service._stream_opportunity_discovery_immediate("user-test", context_task):
+        events.append(update)
+
+    progress_events = [event for event in events if event.get("type") == "progress"]
+    assert progress_events, "expected at least one progress event before completion"
+    assert any("__context__" in event for event in events)


### PR DESCRIPTION
## Summary
- return pending opportunity placeholders immediately and cap the in-memory cache TTL at 5 minutes while the background scan continues
- expose the pending/partial scan metadata in unified chat progress streaming so the UI gets instant status updates
- switch the frontend decision approval call to `/chat/action/confirm` and cover the new discovery flow with targeted async tests

## Testing
- pytest tests/test_opportunity_discovery_pending.py


------
https://chatgpt.com/codex/tasks/task_e_68e3c7a456cc8322864173b76a95dd8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user opportunity caching with placeholder "scanning" responses, background refreshes and portfolio optimization scheduling, and real-time progress events (stages, messages, percent) including an immediate streaming path.

* **Chores**
  * Frontend now calls the updated chat action endpoint.

* **Documentation**
  * Investigation report on opportunity discovery timeouts added.

* **Tests**
  * New tests for pending/partial scan flows and streaming progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->