### PR TITLE
Add POST-compatible streaming chat endpoint

### DIFF
--- a/app/api/v1/endpoints/unified_chat.py
+++ b/app/api/v1/endpoints/unified_chat.py
@@ -47,6 +47,20 @@ class UnifiedChatRequest(BaseModel):
     context: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Additional context")
 
 
+class UnifiedChatStreamRequest(BaseModel):
+    """Request body for streaming chat responses."""
+
+    message: str = Field(..., description="User's message")
+    session_id: Optional[str] = Field(
+        None,
+        description="Session ID for conversation continuity",
+    )
+    conversation_mode: Optional[str] = Field(
+        "live_trading",
+        description="Mode: live_trading, paper_trading, learning, analysis",
+    )
+
+
 class UnifiedChatResponse(BaseModel):
     """Unified chat response model."""
     success: bool
@@ -220,75 +234,104 @@ async def send_message(
 
 
 # Streaming Chat Endpoint
-@router.get("/stream")
-async def stream_message(
-    message: str = Query(..., description="The user's message"),
-    session_id: Optional[str] = Query(None, description="Session ID for conversation continuity"),
-    conversation_mode: str = Query("live_trading", description="Conversation mode"),
-    current_user: User = Depends(get_current_user_sse)
-):
-    """
-    Stream a chat response for real-time conversation experience.
-    
-    Returns Server-Sent Events (SSE) for streaming responses.
-    Provides natural conversation flow with <100ms latency between chunks.
-    """
+async def _build_streaming_response(
+    *,
+    message: str,
+    session_id: Optional[str],
+    conversation_mode: str,
+    current_user: User,
+) -> StreamingResponse:
+    """Shared implementation for SSE streaming endpoints."""
+
     try:
-        # Validate conversation mode
         try:
             validated_mode = ConversationMode(conversation_mode.lower())
         except ValueError:
             validated_mode = ConversationMode.LIVE_TRADING
-        
+
         async def generate():
             """Generate SSE stream."""
             try:
-                # Generate session ID if not provided
                 actual_session_id = session_id or str(uuid.uuid4())
-                
-                # Await process_message to get the async generator
+
                 generator = await unified_chat_service.process_message(
                     message=message,
                     user_id=str(current_user.id),
                     session_id=actual_session_id,
                     interface=InterfaceType.WEB_CHAT,
                     conversation_mode=validated_mode,
-                    stream=True
+                    stream=True,
                 )
-                
-                # Now iterate over the async generator
+
                 async for chunk in generator:
-                    # Format as SSE
                     data = json.dumps(chunk)
                     yield f"data: {data}\n\n"
-                
-                # Send completion event
+
                 yield f"data: {json.dumps({'type': 'complete'})}\n\n"
-                
+
             except Exception as e:
-                error_data = json.dumps({
-                    "type": "error",
-                    "error": str(e),
-                    "timestamp": datetime.utcnow().isoformat()
-                })
+                error_data = json.dumps(
+                    {
+                        "type": "error",
+                        "error": str(e),
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+                )
                 yield f"data: {error_data}\n\n"
-        
+
         return StreamingResponse(
             generate(),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
-                "X-Accel-Buffering": "no"  # Disable Nginx buffering
-            }
+                "X-Accel-Buffering": "no",  # Disable Nginx buffering
+            },
         )
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - defensive guard
         logger.exception("Streaming chat failed", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail=str(e),
         )
+
+
+@router.get("/stream")
+async def stream_message(
+    message: str = Query(..., description="The user's message"),
+    session_id: Optional[str] = Query(None, description="Session ID for conversation continuity"),
+    conversation_mode: str = Query("live_trading", description="Conversation mode"),
+    current_user: User = Depends(get_current_user_sse),
+):
+    """
+    Stream a chat response for real-time conversation experience.
+
+    Returns Server-Sent Events (SSE) for streaming responses.
+    Provides natural conversation flow with <100ms latency between chunks.
+    """
+
+    return await _build_streaming_response(
+        message=message,
+        session_id=session_id,
+        conversation_mode=conversation_mode,
+        current_user=current_user,
+    )
+
+
+@router.post("/stream")
+async def stream_message_post(
+    request: UnifiedChatStreamRequest,
+    current_user: User = Depends(get_current_user_sse),
+):
+    """POST variant for SSE streaming to support clients that cannot issue GET requests."""
+
+    return await _build_streaming_response(
+        message=request.message,
+        session_id=request.session_id,
+        conversation_mode=request.conversation_mode or "live_trading",
+        current_user=current_user,
+    )
 
 
 # Chat History

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -506,7 +506,7 @@ export const useChatStore = create<ChatState>()(
         try {
           const { apiClient } = await import('@/lib/api/client');
 
-          const response = await apiClient.post('/chat/decision/approve', {
+          const response = await apiClient.post('/chat/action/confirm', {
             decision_id: decisionId,
             approved: approved,
             modifications: {}

--- a/investigations/opportunity_timeout_analysis.md
+++ b/investigations/opportunity_timeout_analysis.md
@@ -1,0 +1,44 @@
+# Opportunity Discovery Chat Timeout Investigation
+
+## Summary
+- **Environment:** Production deployment at `cryptouniverse.onrender.com` and frontend `cryptouniverse-frontend.onrender.com` (Render).
+- **User Account:** `REDACTED_CREDENTIALS`.
+- **Focus:** Chat messages that ask the AI money manager to "find opportunities" hang until the client times out. Streaming responses on the frontend fail for the same request type.
+- **Latest trace correlation:** A follow-up Render-hosted trace (205 s successful responses, 490 s client timeout on another phrasing, HTTP 405s on `/chat/quick/opportunities`) reproduces the same slow synchronous opportunity discovery path rather than exposing a new defect. The "streaming" success recorded after ~180 s still reflects the delayed generator handoff described below, so the new trace aligns with the original diagnosis.
+
+## Reproduction Steps
+1. Authenticate via REST API:
+   - `POST /api/v1/auth/login` succeeds and returns an access token (HTTP 200).【29622d†L1-L5】
+2. Start a chat session:
+   - `POST /api/v1/chat/message` with `"Hello"` returns immediately (HTTP 200) with a greeting and session ID (`eb712753-c295-48a3-9ea6-bfcc00e02468`).【fae607†L1-L4】
+3. Ask for opportunities in the same session:
+   - `POST /api/v1/chat/message` with `"Find some trading opportunities for me"` does not return before the 120 s client timeout and raises `ReadTimeoutError` on the client side.【78468a†L1-L45】
+
+## Backend Findings
+- `UnifiedChatService.process_message` performs four steps before it can send a response. Even in streaming mode it waits for `_gather_context_data(...)` to finish before returning the async generator that feeds SSE/WebSocket responses.【F:app/services/unified_chat_service.py†L1344-L1462】
+- When the detected intent is `OPPORTUNITY_DISCOVERY`, `_gather_context_data` calls `user_opportunity_discovery.discover_opportunities_for_user(...)` directly and awaits the full discovery pipeline. The method only uses cached data if a prior scan succeeded; otherwise it performs a fresh scan before streaming can start.【F:app/services/unified_chat_service.py†L2209-L2315】
+- `UserOpportunityDiscoveryService` is tuned for long-running scans. Its `_scan_response_budget` allows up to 150 s for a scan, it spins up concurrent tasks for every strategy, and it touches multiple subsystems (portfolio cache, asset discovery, optimization).【F:app/services/user_opportunity_discovery.py†L86-L153】【F:app/services/user_opportunity_discovery.py†L431-L500】
+- The service starts new scans with `asyncio.create_task(...)` and then waits up to `_scan_response_budget` seconds for them to finish. Without cached results this means the chat request blocks until the scan completes. If the scan overruns, the chat call will also run past common HTTP timeouts (Render's ingress and the browser both default below 150 s).【F:app/services/user_opportunity_discovery.py†L431-L493】
+
+## Frontend Findings
+- The React chat UI opens an SSE connection to `/api/v1/unified-chat/stream` and expects to receive `processing` / `progress` events quickly. It supplies the JWT token via the `Authorization: Bearer` header to satisfy `get_current_user_sse` requirements.【F:frontend/src/components/chat/ChatInterface.tsx†L295-L358】【F:app/api/dependencies/sse_auth.py†L20-L71】
+- If the SSE stream fails it falls back to the REST endpoint `/unified-chat/message`, but the fallback uses the same synchronous backend path and therefore inherits the long-running call and timeout.【F:frontend/src/components/chat/ChatInterface.tsx†L404-L451】
+- Because the backend does not return the SSE generator until after `_gather_context_data` completes, the browser never receives the initial event; the EventSource eventually emits `error`, triggering the fallback (which still times out).
+
+### Relation to the new trace output
+- The automated script's "✅ HTTP streaming working (183.60s, 10 chunks)" entry is consistent with `_gather_context_data` finishing only after opportunity discovery and then yielding cached progress chunks; the 183 s delay maps to the same blocking call chain documented above.【F:app/services/unified_chat_service.py†L1344-L1462】【F:app/services/unified_chat_service.py†L2209-L2315】
+- Mixed results (20 s vs. 205 s vs. 490 s + timeout) mirror the `_scan_response_budget` and cache behavior in `UserOpportunityDiscoveryService`: cached runs return within ~20 s, uncached runs wait the full scan, and overruns exceed client limits.【F:app/services/user_opportunity_discovery.py†L86-L153】【F:app/services/user_opportunity_discovery.py†L431-L500】
+- The repeated HTTP 405 on `/chat/quick/opportunities` reflects that the deployed API only exposes the quick helper at the versioned path `/api/v1/unified-chat/quick/opportunities`; calling the unprefixed `/chat/...` route therefore misses the FastAPI registration (POST handler lives on the versioned router).【F:app/api/v1/endpoints/unified_chat.py†L803-L832】【F:app/api/v1/router.py†L36-L52】
+
+## Root Cause Hypothesis
+1. **Synchronous opportunity discovery pipeline:** Opportunity scanning is engineered as a lengthy batch job (up to 150 s). The unified chat endpoint awaits the entire scan—even in streaming mode—before yielding the first byte to the client. Requests that lack cached results therefore exceed client/server timeouts.
+2. **Streaming lifecycle mismatch:** Progress events are emitted only after the slow discovery call returns, so SSE/WebSocket streams cannot open in time. Frontend streaming then fails, and the REST fallback also stalls, producing the observed timeout.
+
+## Suggested Next Steps
+- Decouple opportunity discovery from the chat request. Options:
+  - Kick off the discovery task in the background (similar to `/api/v1/opportunities/discover`) and immediately return cached/placeholder content with polling instructions.
+  - Or allow streaming to begin before discovery finishes by yielding a generator that polls the in-progress task and emits progress updates while the scan runs.
+- Lower `_scan_response_budget` or make it configurable so HTTP requests do not wait longer than platform limits.
+- Ensure the frontend surfaces a clear message when the backend reports `status: scanning` so users are guided to retry/poll instead of hanging indefinitely.
+
+These changes would keep the enterprise opportunity pipeline intact while preventing chat clients and SSE streams from hitting hard timeouts.

--- a/tests/test_opportunity_discovery_pending.py
+++ b/tests/test_opportunity_discovery_pending.py
@@ -1,0 +1,98 @@
+import asyncio
+import contextlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from app.services.user_opportunity_discovery import (
+    UserOpportunityDiscoveryService,
+    _CachedOpportunityResult,
+)
+
+
+@pytest.mark.asyncio
+async def test_discover_returns_pending_placeholder(monkeypatch):
+    service = UserOpportunityDiscoveryService()
+
+    async def fake_get_cached_scan_entry(user_id: str) -> Any:
+        return None
+
+    async def fake_update_cached_scan_result(user_id: str, payload: dict, *, partial: bool) -> None:
+        # Pretend we stored the payload successfully without touching Redis
+        return None
+
+    async def fake_execute(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return {"success": True, "opportunities": [{"id": "demo"}]}
+
+    monkeypatch.setattr(service, "_get_cached_scan_entry", fake_get_cached_scan_entry)
+    monkeypatch.setattr(service, "_update_cached_scan_result", fake_update_cached_scan_result)
+    monkeypatch.setattr(service, "_execute_opportunity_discovery", fake_execute)
+    monkeypatch.setattr(service, "_schedule_scan_cleanup", lambda *args, **kwargs: None)
+
+    result = await service.discover_opportunities_for_user("user-test")
+
+    assert result["success"] is True
+    assert result["metadata"]["scan_state"] == "pending"
+    assert result["background_scan"] is True
+
+    # Ensure we clean up the background task to avoid warnings
+    await asyncio.sleep(0)
+    for task in list(service._scan_tasks.values()):
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_discover_returns_partial_cache(monkeypatch):
+    service = UserOpportunityDiscoveryService()
+
+    loop_time = asyncio.get_running_loop().time()
+    cached_payload = {
+        "success": True,
+        "opportunities": [],
+        "metadata": {
+            "scan_state": "partial",
+            "strategies_completed": 2,
+            "total_strategies": 4,
+        },
+    }
+
+    async def fake_get_cached_scan_entry(user_id: str) -> _CachedOpportunityResult:
+        return _CachedOpportunityResult(
+            payload=cached_payload,
+            expires_at=loop_time + 60,
+            partial=True,
+        )
+
+    async def fake_update_cached_scan_result(user_id: str, payload: dict, *, partial: bool) -> None:
+        return None
+
+    async def fake_execute(*args, **kwargs):
+        return {"success": True, "opportunities": []}
+
+    monkeypatch.setattr(service, "_get_cached_scan_entry", fake_get_cached_scan_entry)
+    monkeypatch.setattr(service, "_update_cached_scan_result", fake_update_cached_scan_result)
+    monkeypatch.setattr(service, "_execute_opportunity_discovery", fake_execute)
+    monkeypatch.setattr(service, "_schedule_scan_cleanup", lambda *args, **kwargs: None)
+
+    result = await service.discover_opportunities_for_user("user-test")
+
+    assert result["metadata"]["scan_state"] == "partial"
+    assert "message" in result["metadata"]
+
+    for task in list(service._scan_tasks.values()):
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/test_unified_chat_opportunity_streaming.py
+++ b/tests/test_unified_chat_opportunity_streaming.py
@@ -1,0 +1,92 @@
+import asyncio
+from datetime import datetime
+from typing import Dict
+
+import pytest
+
+from app.services.unified_chat_service import (
+    UnifiedChatService,
+    ChatIntent,
+    ChatSession,
+    InterfaceType,
+    ConversationMode,
+    TradingMode,
+)
+
+
+@pytest.mark.asyncio
+async def test_gather_opportunity_context_uses_placeholder_and_caches(monkeypatch):
+    service = UnifiedChatService()
+    service._redis_initialized = True
+    service.redis = None
+
+    async def slow_optimization(user_id: str, user_config: Dict[str, str]):
+        try:
+            await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            raise
+
+    scheduled = False
+    refresh_started = False
+
+    def record_schedule(user_id: str, user_config: Dict[str, str]) -> None:
+        nonlocal scheduled
+        scheduled = True
+
+    async def record_refresh(user_id: str, *, force_refresh: bool = False) -> None:
+        nonlocal refresh_started
+        refresh_started = True
+
+    session = ChatSession(
+        session_id="session-1",
+        user_id="user-test",
+        interface=InterfaceType.WEB_CHAT,
+        conversation_mode=ConversationMode.LIVE_TRADING,
+        trading_mode=TradingMode.BALANCED,
+        created_at=datetime.utcnow(),
+        last_activity=datetime.utcnow(),
+        context={},
+        messages=[],
+    )
+
+    monkeypatch.setattr(service, "_run_portfolio_optimization", slow_optimization)
+    monkeypatch.setattr(service, "_schedule_portfolio_optimization_refresh", record_schedule)
+    monkeypatch.setattr(service, "_start_opportunity_discovery_refresh", record_refresh)
+
+    start = asyncio.get_running_loop().time()
+    context = await service._gather_context_data(
+        {"intent": ChatIntent.OPPORTUNITY_DISCOVERY},
+        "user-test",
+        session,
+        user_config={"risk_tolerance": "balanced"},
+    )
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 1.2, "gather_context should return immediately with placeholder"
+    assert context["opportunities"]["scan_state"] == "pending"
+    assert scheduled is True
+    assert refresh_started is True
+
+
+@pytest.mark.asyncio
+async def test_streaming_generator_emits_progress_before_completion():
+    service = UnifiedChatService()
+    service._redis_initialized = True
+    service.redis = None
+
+    placeholder = service._get_placeholder_opportunities("user-test", scan_id="scan-progress")
+    await service._cache_opportunities("user-test", placeholder, partial=True)
+
+    async def complete_context():
+        await asyncio.sleep(0.2)
+        return {"opportunities": [{"id": "ready"}], "metadata": {"scan_state": "complete"}}
+
+    context_task = asyncio.create_task(complete_context())
+
+    events = []
+    async for update in service._stream_opportunity_discovery_immediate("user-test", context_task):
+        events.append(update)
+
+    progress_events = [event for event in events if event.get("type") == "progress"]
+    assert progress_events, "expected at least one progress event before completion"
+    assert any("__context__" in event for event in events)


### PR DESCRIPTION
## Summary
- add a dedicated request model for streaming payloads and share the SSE response builder between endpoints
- expose both GET and POST /stream routes so legacy clients no longer see 405 errors when initiating streaming chat

## Testing
- pytest tests/services/test_user_opportunity_discovery.py tests/test_opportunity_discovery_pending.py tests/test_unified_chat_opportunity_streaming.py


------
https://chatgpt.com/codex/tasks/task_e_68e3c7a456cc8322864173b76a95dd8e