### PR TITLE
feat: Add detailed backtest trade data with entry/exit, stop loss, ta…

### DIFF
--- a/BACKTEST_TRADE_DATA_ACCESS.md
+++ b/BACKTEST_TRADE_DATA_ACCESS.md
@@ -1,0 +1,249 @@
+# Accessing Detailed Backtest Trade Data
+
+## Overview
+
+The enhanced backtesting engine now captures complete trade information including:
+- **Entry and Exit** prices and timestamps
+- **Position Type** (LONG/SHORT)
+- **Stop Loss** and **Take Profit** levels
+- **Exit Reason** (TAKE_PROFIT, STOP_LOSS, MANUAL, BACKTEST_END)
+- **PnL** and **Outcome** (WIN/LOSS/BREAKEVEN)
+
+## Data Structure
+
+Each trade in `closed_trades` array contains:
+
+```json
+{
+  "trade_id": "BTC/USDT_2024-01-15T10:30:00_2024-01-16T14:20:00",
+  "symbol": "BTC/USDT",
+  "position_type": "LONG",  // or "SHORT"
+  "entry_time": "2024-01-15T10:30:00",
+  "exit_time": "2024-01-16T14:20:00",
+  "entry_price": 45000.0,
+  "exit_price": 46500.0,
+  "quantity": 0.1,
+  "stop_loss": 44000.0,  // or null if not set
+  "take_profit": 47000.0,  // or null if not set
+  "exit_reason": "TAKE_PROFIT",  // TAKE_PROFIT, STOP_LOSS, MANUAL, BACKTEST_END
+  "pnl": 150.0,
+  "pnl_pct": 3.33,
+  "fees": 0.465,
+  "cost_basis": 4500.0,
+  "outcome": "WIN"  // WIN, LOSS, or BREAKEVEN
+}
+```
+
+## API Endpoints
+
+### 1. Get All Backtest Results (Summary)
+
+**Endpoint:** `GET /api/v1/strategies/backtest-results`
+
+**Query Parameters:**
+- `strategy_id` (optional): Filter by strategy ID
+- `limit` (default: 10): Number of results (1-100)
+- `skip` (default: 0): Pagination offset
+
+**Response:**
+```json
+{
+  "success": true,
+  "count": 5,
+  "results": [
+    {
+      "id": "uuid-here",
+      "strategy_id": "momentum_strategy",
+      "strategy_name": "Momentum Trading",
+      "start_date": "2024-01-01T00:00:00",
+      "end_date": "2024-04-01T00:00:00",
+      "total_trades": 42,
+      "win_rate": 65.5,
+      "total_return_pct": 12.5,
+      "profit_factor": 1.85,
+      "sharpe_ratio": 1.2,
+      "max_drawdown": 8.5,
+      "created_at": "2024-04-01T12:00:00"
+    }
+  ]
+}
+```
+
+### 2. Get Detailed Backtest Result with All Trades
+
+**Endpoint:** `GET /api/v1/strategies/backtest-results/{backtest_id}`
+
+**Path Parameters:**
+- `backtest_id`: UUID or strategy_id
+
+**Query Parameters:**
+- `include_trades` (default: true): Include detailed trade records
+
+**Response:**
+```json
+{
+  "success": true,
+  "backtest_id": "uuid-here",
+  "strategy_id": "momentum_strategy",
+  "strategy_name": "Momentum Trading",
+  "start_date": "2024-01-01T00:00:00",
+  "end_date": "2024-04-01T00:00:00",
+  "period_days": 90,
+  "initial_capital": 10000.0,
+  "final_capital": 11250.0,
+  "total_return": 1250.0,
+  "total_return_pct": 12.5,
+  "total_trades": 42,
+  "winning_trades": 28,
+  "losing_trades": 14,
+  "win_rate": 66.67,
+  "profit_factor": 1.85,
+  "sharpe_ratio": 1.2,
+  "max_drawdown": 8.5,
+  "symbols": ["BTC/USDT", "ETH/USDT"],
+  "data_source": "real_market_data",
+  "created_at": "2024-04-01T12:00:00",
+  "total_trades_detailed": 42,
+  "trades": [
+    {
+      "trade_id": "BTC/USDT_2024-01-15T10:30:00_2024-01-16T14:20:00",
+      "symbol": "BTC/USDT",
+      "position_type": "LONG",
+      "entry_time": "2024-01-15T10:30:00",
+      "exit_time": "2024-01-16T14:20:00",
+      "entry_price": 45000.0,
+      "exit_price": 46500.0,
+      "quantity": 0.1,
+      "stop_loss": 44000.0,
+      "take_profit": 47000.0,
+      "exit_reason": "TAKE_PROFIT",
+      "pnl": 150.0,
+      "pnl_pct": 3.33,
+      "fees": 0.465,
+      "cost_basis": 4500.0,
+      "outcome": "WIN"
+    },
+    // ... 41 more trades
+  ]
+}
+```
+
+## Code Examples
+
+### Python - Access from Backtest Results
+
+```python
+# After running a backtest
+backtest_result = await real_backtesting_engine.run_backtest(...)
+
+# Access detailed trades
+closed_trades = backtest_result.get('closed_trades', [])
+
+# Filter trades by outcome
+winning_trades = [t for t in closed_trades if t['outcome'] == 'WIN']
+losing_trades = [t for t in closed_trades if t['outcome'] == 'LOSS']
+
+# Filter by exit reason
+take_profit_trades = [t for t in closed_trades if t['exit_reason'] == 'TAKE_PROFIT']
+stop_loss_trades = [t for t in closed_trades if t['exit_reason'] == 'STOP_LOSS']
+
+# Get all LONG positions
+long_trades = [t for t in closed_trades if t['position_type'] == 'LONG']
+
+# Calculate average win/loss
+avg_win = sum(t['pnl'] for t in winning_trades) / len(winning_trades) if winning_trades else 0
+avg_loss = sum(t['pnl'] for t in losing_trades) / len(losing_trades) if losing_trades else 0
+```
+
+### JavaScript/TypeScript - Frontend Access
+
+```typescript
+// Fetch detailed backtest results
+const response = await fetch('/api/v1/strategies/backtest-results/{backtest_id}', {
+  headers: {
+    'Authorization': `Bearer ${token}`
+  }
+});
+
+const data = await response.json();
+
+// Access all 42 trades
+const trades = data.trades;
+
+// Filter and analyze
+const longTrades = trades.filter(t => t.position_type === 'LONG');
+const shortTrades = trades.filter(t => t.position_type === 'SHORT');
+const takeProfitExits = trades.filter(t => t.exit_reason === 'TAKE_PROFIT');
+const stopLossExits = trades.filter(t => t.exit_reason === 'STOP_LOSS');
+
+// Calculate metrics
+const avgEntryPrice = trades.reduce((sum, t) => sum + t.entry_price, 0) / trades.length;
+const avgExitPrice = trades.reduce((sum, t) => sum + t.exit_price, 0) / trades.length;
+```
+
+## Database Access
+
+Trades are stored in the `backtest_results` table:
+
+```sql
+-- Get backtest with detailed trades
+SELECT 
+    id,
+    strategy_id,
+    strategy_name,
+    total_trades,
+    execution_params->'closed_trades' as detailed_trades
+FROM backtest_results
+WHERE user_id = 'your-user-id'
+ORDER BY created_at DESC
+LIMIT 10;
+
+-- Count trades by exit reason
+SELECT 
+    strategy_id,
+    jsonb_array_length(execution_params->'closed_trades') as total_trades,
+    COUNT(*) FILTER (WHERE trade->>'exit_reason' = 'TAKE_PROFIT') as take_profit_count,
+    COUNT(*) FILTER (WHERE trade->>'exit_reason' = 'STOP_LOSS') as stop_loss_count
+FROM backtest_results,
+     jsonb_array_elements(execution_params->'closed_trades') as trade
+GROUP BY strategy_id;
+```
+
+## Implementation Details
+
+### Enhanced Backtesting Engine
+
+The `RealBacktestingEngine` now:
+1. **Tracks positions** with entry details (stop_loss, take_profit, position_type)
+2. **Monitors exits** - checks stop loss/take profit on each timestamp
+3. **Creates complete trade records** when positions are closed
+4. **Stores in database** - `execution_params.closed_trades` JSONB field
+
+### Position Tracking
+
+- **LONG positions**: Created on BUY signals
+- **SHORT positions**: Created on SELL signals (if supported)
+- **Multiple entries**: FIFO (First In, First Out) matching
+- **Automatic exits**: Stop loss and take profit checked every timestamp
+
+### Exit Reasons
+
+- `TAKE_PROFIT`: Price hit take profit target
+- `STOP_LOSS`: Price hit stop loss level
+- `MANUAL`: Manual close via SELL signal
+- `BACKTEST_END`: Position still open at end of backtest period
+
+## Example: Get All 42 Trades
+
+```bash
+# Get backtest result ID first
+curl -X GET "https://api.cryptouniverse.com/api/v1/strategies/backtest-results?strategy_id=momentum_strategy" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Then get detailed trades
+curl -X GET "https://api.cryptouniverse.com/api/v1/strategies/backtest-results/{backtest_id}?include_trades=true" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+The response will include all trades in the `trades` array, each with complete entry/exit, stop loss, take profit, and position type information.
+

--- a/app/api/v1/endpoints/backtest_results.py
+++ b/app/api/v1/endpoints/backtest_results.py
@@ -1,0 +1,176 @@
+"""
+Backtest Results API Endpoints
+
+Provides endpoints to retrieve detailed backtest results including
+individual trade records with entry/exit, stop loss, take profit, and position type.
+"""
+
+from typing import List, Optional
+from datetime import datetime
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, and_, desc
+
+from app.core.database import get_database
+from app.api.v1.endpoints.auth import get_current_user
+from app.models.user import User
+from app.models.market_data import BacktestResult
+
+logger = structlog.get_logger(__name__)
+router = APIRouter()
+
+
+@router.get("/backtest-results")
+async def get_backtest_results(
+    strategy_id: Optional[str] = Query(None, description="Filter by strategy ID"),
+    limit: int = Query(10, ge=1, le=100, description="Number of results to return"),
+    skip: int = Query(0, ge=0, description="Number of results to skip"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_database)
+) -> dict:
+    """
+    Get backtest results for the current user.
+    
+    Returns list of backtest results with summary metrics.
+    """
+    try:
+        query = select(BacktestResult).where(
+            BacktestResult.user_id == current_user.id
+        )
+        
+        if strategy_id:
+            query = query.where(BacktestResult.strategy_id == strategy_id)
+        
+        query = query.order_by(desc(BacktestResult.created_at)).offset(skip).limit(limit)
+        
+        result = await db.execute(query)
+        backtests = result.scalars().all()
+        
+        return {
+            "success": True,
+            "count": len(backtests),
+            "results": [
+                {
+                    "id": str(bt.id),
+                    "strategy_id": bt.strategy_id,
+                    "strategy_name": bt.strategy_name,
+                    "start_date": bt.start_date.isoformat(),
+                    "end_date": bt.end_date.isoformat(),
+                    "total_trades": bt.total_trades,
+                    "win_rate": float(bt.win_rate) if bt.win_rate else 0,
+                    "total_return_pct": float(bt.total_return_pct) if bt.total_return_pct else 0,
+                    "profit_factor": float(bt.profit_factor) if bt.profit_factor else 0,
+                    "sharpe_ratio": float(bt.sharpe_ratio) if bt.sharpe_ratio else 0,
+                    "max_drawdown": float(bt.max_drawdown) if bt.max_drawdown else 0,
+                    "created_at": bt.created_at.isoformat()
+                }
+                for bt in backtests
+            ]
+        }
+    except Exception as e:
+        logger.error("Failed to get backtest results", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve backtest results: {str(e)}"
+        )
+
+
+@router.get("/backtest-results/{backtest_id}")
+async def get_backtest_result_details(
+    backtest_id: str,
+    include_trades: bool = Query(True, description="Include detailed trade records"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_database)
+) -> dict:
+    """
+    Get detailed backtest result including all individual trades.
+    
+    Returns complete backtest data including:
+    - All 42 (or more) individual trades
+    - Entry and exit prices/times
+    - Position type (LONG/SHORT)
+    - Stop loss and take profit levels
+    - Exit reason (TAKE_PROFIT, STOP_LOSS, MANUAL, BACKTEST_END)
+    - PnL and outcome (WIN/LOSS/BREAKEVEN)
+    """
+    try:
+        # Convert string ID to UUID if needed
+        try:
+            bt_uuid = UUID(backtest_id)
+        except ValueError:
+            # Try finding by strategy_id if UUID fails
+            query = select(BacktestResult).where(
+                and_(
+                    BacktestResult.strategy_id == backtest_id,
+                    BacktestResult.user_id == current_user.id
+                )
+            ).order_by(desc(BacktestResult.created_at)).limit(1)
+        else:
+            query = select(BacktestResult).where(
+                and_(
+                    BacktestResult.id == bt_uuid,
+                    BacktestResult.user_id == current_user.id
+                )
+            )
+        
+        result = await db.execute(query)
+        backtest = result.scalar_one_or_none()
+        
+        if not backtest:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Backtest result not found"
+            )
+        
+        # Extract detailed trades from execution_params
+        closed_trades = []
+        if backtest.execution_params and isinstance(backtest.execution_params, dict):
+            closed_trades = backtest.execution_params.get('closed_trades', [])
+        
+        # Fallback to trade_log if closed_trades not available
+        if not closed_trades and backtest.trade_log:
+            # Convert legacy format if needed
+            closed_trades = backtest.trade_log if isinstance(backtest.trade_log, list) else []
+        
+        response = {
+            "success": True,
+            "backtest_id": str(backtest.id),
+            "strategy_id": backtest.strategy_id,
+            "strategy_name": backtest.strategy_name,
+            "start_date": backtest.start_date.isoformat(),
+            "end_date": backtest.end_date.isoformat(),
+            "period_days": (backtest.end_date - backtest.start_date).days,
+            "initial_capital": float(backtest.initial_capital),
+            "final_capital": float(backtest.final_capital),
+            "total_return": float(backtest.total_return) if backtest.total_return else 0,
+            "total_return_pct": float(backtest.total_return_pct) if backtest.total_return_pct else 0,
+            "total_trades": backtest.total_trades,
+            "winning_trades": backtest.winning_trades,
+            "losing_trades": backtest.losing_trades,
+            "win_rate": float(backtest.win_rate) if backtest.win_rate else 0,
+            "profit_factor": float(backtest.profit_factor) if backtest.profit_factor else 0,
+            "sharpe_ratio": float(backtest.sharpe_ratio) if backtest.sharpe_ratio else 0,
+            "max_drawdown": float(backtest.max_drawdown) if backtest.max_drawdown else 0,
+            "symbols": backtest.symbols if isinstance(backtest.symbols, list) else [],
+            "data_source": backtest.data_source,
+            "created_at": backtest.created_at.isoformat()
+        }
+        
+        if include_trades:
+            response["trades"] = closed_trades
+            response["total_trades_detailed"] = len(closed_trades)
+        
+        return response
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to get backtest result details", error=str(e), backtest_id=backtest_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve backtest details: {str(e)}"
+        )
+

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -18,7 +18,8 @@ from app.api.v1.endpoints import (
     auth, trading, admin, exchanges, strategies, credits,
     telegram, paper_trading, unified_chat, market_analysis, api_keys, ai_consensus,
     password_reset, health, opportunity_discovery, admin_testing, ab_testing, admin_strategy_access,
-    signals, unified_strategies, risk, diagnostics, scan_diagnostics, system_monitoring
+    signals, unified_strategies, risk, diagnostics, scan_diagnostics, system_monitoring,
+    backtest_results
 )
 
 from app.core.database import AsyncSessionLocal
@@ -38,6 +39,7 @@ api_router.include_router(api_keys.router, prefix="/api-keys", tags=["API Keys"]
 api_router.include_router(trading.router, prefix="/trading", tags=["Trading"])
 api_router.include_router(exchanges.router, prefix="/exchanges", tags=["Exchanges"])
 api_router.include_router(strategies.router, prefix="/strategies", tags=["Strategies"])
+api_router.include_router(backtest_results.router, prefix="/strategies", tags=["Backtest Results"])
 api_router.include_router(credits.router, prefix="/credits", tags=["Credits"])
 api_router.include_router(telegram.router, prefix="/telegram", tags=["Telegram"])
 api_router.include_router(paper_trading.router, prefix="/paper-trading", tags=["Paper Trading"])


### PR DESCRIPTION
…ke profit, and position type

- Enhanced RealBacktestingEngine to track complete trade details:
  * Entry and exit prices/times
  * Position type (LONG/SHORT)
  * Stop loss and take profit levels
  * Exit reasons (TAKE_PROFIT, STOP_LOSS, MANUAL, BACKTEST_END)
  * PnL, fees, and outcome (WIN/LOSS/BREAKEVEN)

- Added new API endpoints for accessing detailed backtest results:
  * GET /api/v1/strategies/backtest-results - List all backtest results
  * GET /api/v1/strategies/backtest-results/{id} - Get detailed results with all trades

- Enhanced position tracking with automatic stop loss/take profit monitoring
- Stores detailed trades in execution_params.closed_trades JSONB field
- Added comprehensive documentation in BACKTEST_TRADE_DATA_ACCESS.md